### PR TITLE
Add WordPress plugin entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## WordPress Installation
+
+1. Run `npm install` to install dependencies.
+2. Build the React app with `npm run build`. This creates a `dist/` directory containing the final JavaScript and CSS assets.
+3. Copy the repository (or just the `cookie-consent-king.php` file and the `dist/` directory) into your WordPress `wp-content/plugins/` folder.
+4. Activate **Cookie Consent King** from the Plugins menu in WordPress.
+
+## Usage
+
+Once activated, the plugin automatically enqueues the built assets on the front end. After building the React project, you should see the cookie consent banner appear on your site.
+

--- a/cookie-consent-king.php
+++ b/cookie-consent-king.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Plugin Name: Cookie Consent King
+ * Plugin URI: https://example.com
+ * Description: Provides a React-powered cookie consent banner.
+ * Version: 1.0.0
+ * Author: Your Name
+ * License: GPL2
+ */
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly.
+}
+
+function cck_enqueue_assets() {
+    $asset_path = plugin_dir_path(__FILE__) . 'dist/assets/';
+
+    $js_files = glob($asset_path . '*.js');
+    if ($js_files) {
+        $js_file = basename($js_files[0]);
+        wp_enqueue_script(
+            'cookie-consent-king-js',
+            plugin_dir_url(__FILE__) . 'dist/assets/' . $js_file,
+            [],
+            null,
+            true
+        );
+    }
+
+    $css_files = glob($asset_path . '*.css');
+    if ($css_files) {
+        $css_file = basename($css_files[0]);
+        wp_enqueue_style(
+            'cookie-consent-king-css',
+            plugin_dir_url(__FILE__) . 'dist/assets/' . $css_file,
+            [],
+            null
+        );
+    }
+}
+add_action('wp_enqueue_scripts', 'cck_enqueue_assets');
+
+function cck_activate() {
+    // Placeholder for activation logic.
+}
+register_activation_hook(__FILE__, 'cck_activate');
+
+function cck_deactivate() {
+    // Placeholder for deactivation logic.
+}
+register_deactivation_hook(__FILE__, 'cck_deactivate');
+
+?>


### PR DESCRIPTION
## Summary
- add `cookie-consent-king.php` with plugin header and asset enqueuing logic
- document how to build and install the plugin in WordPress

## Testing
- `npm run lint` *(fails: prefer-rest-params, no-explicit-any, no-empty-object-type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688d148df6bc83309e826e2a2b4d2121