### PR TITLE
Add typed interfaces for analytics

### DIFF
--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
@@ -24,10 +24,25 @@ interface CookieBannerProps {
 }
 
 // Consent Mode v2 integration
+interface Gtag {
+  (
+    command: 'consent' | 'config' | 'event',
+    action: string,
+    params?: Record<string, unknown>
+  ): void;
+  (...args: unknown[]): void;
+}
+
+type DataLayerEvent = Record<string, unknown>;
+
+interface DataLayer extends Array<DataLayerEvent> {
+  push: (...args: DataLayerEvent[]) => number;
+}
+
 declare global {
   interface Window {
-    gtag?: (...args: any[]) => void;
-    dataLayer?: any[];
+    gtag?: Gtag;
+    dataLayer?: DataLayer;
   }
 }
 
@@ -61,7 +76,7 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
       setShowBanner(false);
       setShowMiniBanner(true); // Show mini banner when consent exists
     }
-  }, []);
+  }, [updateConsentMode]);
 
   const initializeConsentMode = () => {
     if (typeof window !== 'undefined' && window.gtag) {
@@ -116,25 +131,28 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
     }
   };
 
-  const updateConsentMode = (consentSettings: ConsentSettings, action?: string) => {
-    if (typeof window !== 'undefined' && window.gtag) {
-      window.gtag('consent', 'update', {
-        'ad_storage': consentSettings.marketing ? 'granted' : 'denied',
-        'ad_user_data': consentSettings.marketing ? 'granted' : 'denied',
-        'ad_personalization': consentSettings.marketing ? 'granted' : 'denied',
-        'analytics_storage': consentSettings.analytics ? 'granted' : 'denied',
-        'functionality_storage': consentSettings.preferences ? 'granted' : 'denied',
-        'personalization_storage': consentSettings.preferences ? 'granted' : 'denied',
-      });
-    }
+  const updateConsentMode = useCallback(
+    (consentSettings: ConsentSettings, action?: string) => {
+      if (typeof window !== 'undefined' && window.gtag) {
+        window.gtag('consent', 'update', {
+          'ad_storage': consentSettings.marketing ? 'granted' : 'denied',
+          'ad_user_data': consentSettings.marketing ? 'granted' : 'denied',
+          'ad_personalization': consentSettings.marketing ? 'granted' : 'denied',
+          'analytics_storage': consentSettings.analytics ? 'granted' : 'denied',
+          'functionality_storage': consentSettings.preferences ? 'granted' : 'denied',
+          'personalization_storage': consentSettings.preferences ? 'granted' : 'denied',
+        });
+      }
 
-    // Push consent_update event to dataLayer
-    if (action) {
-      pushDataLayerEvent(consentSettings, action);
-    }
+      // Push consent_update event to dataLayer
+      if (action) {
+        pushDataLayerEvent(consentSettings, action);
+      }
 
-    onConsentUpdate?.(consentSettings);
-  };
+      onConsentUpdate?.(consentSettings);
+    },
+    [onConsentUpdate]
+  );
 
   const saveConsent = (consentSettings: ConsentSettings, action: string) => {
     console.log('Saving consent:', consentSettings, 'Action:', action);

--- a/src/hooks/useConsentMode.ts
+++ b/src/hooks/useConsentMode.ts
@@ -7,10 +7,25 @@ interface ConsentSettings {
   preferences: boolean;
 }
 
+interface Gtag {
+  (
+    command: 'consent' | 'config' | 'event',
+    action: string,
+    params?: Record<string, unknown>
+  ): void;
+  (...args: unknown[]): void;
+}
+
+type DataLayerEvent = Record<string, unknown>;
+
+interface DataLayer extends Array<DataLayerEvent> {
+  push: (...args: DataLayerEvent[]) => number;
+}
+
 declare global {
   interface Window {
-    gtag?: (...args: any[]) => void;
-    dataLayer?: any[];
+    gtag?: Gtag;
+    dataLayer?: DataLayer;
   }
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,13 +5,14 @@ import { Badge } from '@/components/ui/badge';
 import CookieBanner from '@/components/CookieBanner';
 import ConsentModeScript from '@/components/ConsentModeScript';
 import { useConsentMode } from '@/hooks/useConsentMode';
+import type { ConsentSettings } from '@/utils/cookieManager';
 import { Cookie, Shield, CheckCircle, Settings } from 'lucide-react';
 
 const Index = () => {
   const { consent, isConsentGiven, resetConsent, getConsentDate } = useConsentMode();
   const [showDemo, setShowDemo] = useState(false);
 
-  const handleConsentUpdate = (newConsent: any) => {
+  const handleConsentUpdate = (newConsent: ConsentSettings) => {
     console.log('Consent updated:', newConsent);
     setShowDemo(false); // Cerrar el banner demo cuando se actualice el consentimiento
     // Aquí puedes agregar lógica adicional cuando se actualice el consentimiento


### PR DESCRIPTION
## Summary
- define explicit Gtag and DataLayer types
- use ConsentSettings instead of any in Index page
- ensure banner effect includes updateConsentMode dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688d148f142c8330a313e4d313a467e5