### PR TITLE
Add vitest and cookieManager tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Running tests
+
+Install dependencies and run the Vitest suite:
+
+```sh
+npm install
+npm test
+```
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/1da458a0-5313-4e8e-8699-a605a08fdfea) and click on Share -> Publish.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -78,6 +79,8 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/utils/__tests__/cookieManager.test.ts
+++ b/src/utils/__tests__/cookieManager.test.ts
@@ -1,0 +1,41 @@
+import { cookieManager } from '../cookieManager';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const sampleConsent = {
+  necessary: true,
+  analytics: true,
+  marketing: false,
+  preferences: true,
+};
+
+describe('cookieManager', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    cookieManager.resetConsent();
+  });
+
+  it('updateConsent stores consent and dispatches event', () => {
+    const handler = vi.fn();
+    window.addEventListener('consentUpdated', handler);
+    cookieManager.updateConsent(sampleConsent);
+
+    expect(cookieManager.getConsent()).toEqual(sampleConsent);
+    expect(localStorage.getItem('cookieConsent')).toEqual(JSON.stringify(sampleConsent));
+    expect(localStorage.getItem('cookieConsentDate')).not.toBeNull();
+    expect(handler).toHaveBeenCalled();
+    window.removeEventListener('consentUpdated', handler);
+  });
+
+  it('resetConsent clears consent and dispatches event', () => {
+    cookieManager.updateConsent(sampleConsent);
+    const handler = vi.fn();
+    window.addEventListener('consentReset', handler);
+    cookieManager.resetConsent();
+
+    expect(cookieManager.getConsent()).toBeNull();
+    expect(localStorage.getItem('cookieConsent')).toBeNull();
+    expect(localStorage.getItem('cookieConsentDate')).toBeNull();
+    expect(handler).toHaveBeenCalled();
+    window.removeEventListener('consentReset', handler);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add vitest configuration
- add tests for cookieManager
- document how to run tests

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm install --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688d14911af48330869713b905aeea32