### PR TITLE
Add WordPress admin menu

### DIFF
--- a/cookie-consent-king.php
+++ b/cookie-consent-king.php
@@ -50,4 +50,109 @@ function cck_deactivate() {
 }
 register_deactivation_hook(__FILE__, 'cck_deactivate');
 
+// -----------------------------------------------------------------------------
+// Admin Menu Setup
+// -----------------------------------------------------------------------------
+
+/**
+ * Register the Consent King admin menu and submenus.
+ */
+function cck_register_admin_menu() {
+    // Top level menu.
+    add_menu_page(
+        __('Consent King', 'cookie-consent-king'),
+        __('Consent King', 'cookie-consent-king'),
+        'manage_options',
+        'cck-dashboard',
+        'cck_render_dashboard',
+        'dashicons-carrot'
+    );
+
+    // Submenu: Dashboard.
+    add_submenu_page(
+        'cck-dashboard',
+        __('Dashboard', 'cookie-consent-king'),
+        __('Dashboard', 'cookie-consent-king'),
+        'manage_options',
+        'cck-dashboard',
+        'cck_render_dashboard'
+    );
+
+    // Submenu: Banner Styles.
+    add_submenu_page(
+        'cck-dashboard',
+        __('Banner Styles', 'cookie-consent-king'),
+        __('Banner Styles', 'cookie-consent-king'),
+        'manage_options',
+        'cck-banner-styles',
+        'cck_render_banner_styles'
+    );
+
+    // Submenu: Default Texts.
+    add_submenu_page(
+        'cck-dashboard',
+        __('Default Texts', 'cookie-consent-king'),
+        __('Default Texts', 'cookie-consent-king'),
+        'manage_options',
+        'cck-default-texts',
+        'cck_render_default_texts'
+    );
+
+    // Submenu: Basic Configuration.
+    add_submenu_page(
+        'cck-dashboard',
+        __('Basic Configuration', 'cookie-consent-king'),
+        __('Basic Configuration', 'cookie-consent-king'),
+        'manage_options',
+        'cck-basic-configuration',
+        'cck_render_basic_configuration'
+    );
+
+    // Submenu: Cookie List/Analysis.
+    add_submenu_page(
+        'cck-dashboard',
+        __('Cookie List/Analysis', 'cookie-consent-king'),
+        __('Cookie List/Analysis', 'cookie-consent-king'),
+        'manage_options',
+        'cck-cookie-list',
+        'cck_render_cookie_list'
+    );
+}
+add_action('admin_menu', 'cck_register_admin_menu');
+
+/**
+ * Render the Dashboard screen.
+ */
+function cck_render_dashboard() {
+    echo '<div class="wrap"><h1>' . esc_html__('Dashboard', 'cookie-consent-king') . '</h1><p>' . esc_html__('Admin dashboard placeholder.', 'cookie-consent-king') . '</p></div>';
+}
+
+/**
+ * Render the Banner Styles screen.
+ */
+function cck_render_banner_styles() {
+    echo '<div class="wrap"><h1>' . esc_html__('Banner Styles', 'cookie-consent-king') . '</h1><p>' . esc_html__('Placeholder for banner styles.', 'cookie-consent-king') . '</p></div>';
+}
+
+/**
+ * Render the Default Texts screen.
+ */
+function cck_render_default_texts() {
+    echo '<div class="wrap"><h1>' . esc_html__('Default Texts', 'cookie-consent-king') . '</h1><p>' . esc_html__('Placeholder for default texts.', 'cookie-consent-king') . '</p></div>';
+}
+
+/**
+ * Render the Basic Configuration screen.
+ */
+function cck_render_basic_configuration() {
+    echo '<div class="wrap"><h1>' . esc_html__('Basic Configuration', 'cookie-consent-king') . '</h1><p>' . esc_html__('Placeholder for basic configuration.', 'cookie-consent-king') . '</p></div>';
+}
+
+/**
+ * Render the Cookie List/Analysis screen.
+ */
+function cck_render_cookie_list() {
+    echo '<div class="wrap"><h1>' . esc_html__('Cookie List/Analysis', 'cookie-consent-king') . '</h1><p>' . esc_html__('Placeholder for cookie list or analysis.', 'cookie-consent-king') . '</p></div>';
+}
+
 ?>


### PR DESCRIPTION
## Summary
- register Consent King admin menu using `add_menu_page`
- add submenu items for Dashboard, Banner Styles, Default Texts, Basic Configuration, and Cookie List/Analysis
- implement placeholder callbacks

## Testing
- `php -l cookie-consent-king.php`
- `npm test` (Vitest)

------
https://chatgpt.com/codex/tasks/task_e_688d1a42f0d48330b686ccfa229693f5