### PR TITLE
Switch Vitest to run mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- run vitest without watch by default

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688d1ddbc0488330810ac2dddea0f620