### PR TITLE
Update plugin header information

### DIFF
--- a/cookie-consent-king.php
+++ b/cookie-consent-king.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * Plugin Name: Cookie Consent King
- * Plugin URI: https://example.com
+ * Plugin URI: https://www.metricaweb.es
  * Description: Provides a React-powered cookie consent banner.
- * Version: 1.0.0
- * Author: Your Name
+ * Version: 2.0
+ * Author: David Adell (Metricaweb) & Oscar Garcia
  * License: GPL2
 
 */


### PR DESCRIPTION
## Summary
- update plugin header to show version 2.0
- set author to David Adell (Metricaweb) & Oscar Garcia
- reference https://www.metricaweb.es in the header

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_688d1dd7f750833085489afd240d1341