### PR TITLE
Add packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,14 @@ The following files and folders are required on the server:
 - `dist/` – the compiled JavaScript and CSS assets from the build step.
 - `languages/*.mo` – compiled translation files.
 
+After building you can package the plugin into a distributable archive using the
+helper script:
+
+```sh
+./scripts/build-plugin.sh
+```
+
+This script creates `cookie-consent-king.zip` containing only the necessary
+files so development folders like `src/`, `public/` and `node_modules/` are
+excluded.
+

--- a/scripts/build-plugin.sh
+++ b/scripts/build-plugin.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+# Determine repository root (directory containing this script's parent)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Copy plugin PHP file
+cp "$ROOT_DIR/cookie-consent-king.php" "$TMP_DIR/"
+
+# Copy built assets
+if [[ -d "$ROOT_DIR/dist" ]]; then
+  cp -R "$ROOT_DIR/dist" "$TMP_DIR/dist"
+else
+  echo "dist/ directory not found. Run 'npm run build' first." >&2
+  exit 1
+fi
+
+# Copy compiled translations (.mo files)
+if ls "$ROOT_DIR"/languages/*.mo >/dev/null 2>&1; then
+  mkdir -p "$TMP_DIR/languages"
+  cp "$ROOT_DIR"/languages/*.mo "$TMP_DIR/languages/"
+fi
+
+ZIP_PATH="$ROOT_DIR/cookie-consent-king.zip"
+
+( cd "$TMP_DIR" && zip -r "$ZIP_PATH" . )
+
+echo "Created $ZIP_PATH"


### PR DESCRIPTION
## Summary
- add `scripts/build-plugin.sh` for packaging the WordPress plugin
- document usage of packaging script in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d22a1c4588330aa0606d4188ecc6c