### PR TITLE
Check asset files before enqueueing and version with filemtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,16 @@ Use the plugin wrapper (`cookie-consent-king.php`) to load the build output:
 ```php
 function cck_enqueue_assets() {
     $plugin_url = plugin_dir_url(__FILE__);
-    wp_enqueue_style('cck-style', $plugin_url . 'dist/assets/index.css', [], COOKIE_CONSENT_KING_VERSION);
-    wp_enqueue_script('cck-script', $plugin_url . 'dist/assets/index.js', [], COOKIE_CONSENT_KING_VERSION, true);
+    $js_path  = plugin_dir_path(__FILE__) . 'dist/assets/index.js';
+    $css_path = plugin_dir_path(__FILE__) . 'dist/assets/index.css';
+
+    if (!file_exists($js_path) || !file_exists($css_path)) {
+        wp_admin_notice('Cookie Consent King assets not found.', ['type' => 'error']);
+        return;
+    }
+
+    wp_enqueue_style('cck-style', $plugin_url . 'dist/assets/index.css', [], filemtime($css_path));
+    wp_enqueue_script('cck-script', $plugin_url . 'dist/assets/index.js', [], filemtime($js_path), true);
 }
 add_action('wp_enqueue_scripts', 'cck_enqueue_assets');
 ```

--- a/cookie-consent-king.php
+++ b/cookie-consent-king.php
@@ -20,19 +20,28 @@ if (!defined('COOKIE_CONSENT_KING_VERSION')) {
 
 function cck_enqueue_assets() {
     $asset_path = plugin_dir_path(__FILE__) . 'dist/assets/';
+    $asset_url  = plugin_dir_url(__FILE__) . 'dist/assets/';
 
-    $js_files = glob($asset_path . '*.js');
-    if ($js_files) {
-        $js_file = basename($js_files[0]);
-        wp_enqueue_script(
-            'cookie-consent-king-js',
-            plugin_dir_url(__FILE__) . 'dist/assets/' . $js_file,
-            [],
-            COOKIE_CONSENT_KING_VERSION,
-            true
+    $js_path  = $asset_path . 'index.js';
+    $css_path = $asset_path . 'index.css';
+
+    if (!file_exists($js_path) || !file_exists($css_path)) {
+        wp_admin_notice(
+            __('Cookie Consent King: assets not found. Please run "npm run build".', 'cookie-consent-king'),
+            ['type' => 'error']
         );
+        return;
+    }
 
-        $translations = [
+    wp_enqueue_script(
+        'cookie-consent-king-js',
+        $asset_url . 'index.js',
+        [],
+        filemtime($js_path),
+        true
+    );
+
+    $translations = [
             'Banner de cookies moderno con soporte completo para Google Consent Mode v2' => __('Banner de cookies moderno con soporte completo para Google Consent Mode v2', 'cookie-consent-king'),
             'Cumplimiento GDPR' => __('Cumplimiento GDPR', 'cookie-consent-king'),
             'Cumple totalmente con las regulaciones GDPR y otras leyes de privacidad internacionales.' => __('Cumple totalmente con las regulaciones GDPR y otras leyes de privacidad internacionales.', 'cookie-consent-king'),
@@ -97,19 +106,14 @@ function cck_enqueue_assets() {
             'Cookies estadísticas' => __('Cookies estadísticas', 'cookie-consent-king'),
             'Cookies de marketing' => __('Cookies de marketing', 'cookie-consent-king'),
         ];
-        wp_localize_script('cookie-consent-king-js', 'cckTranslations', $translations);
-    }
+    wp_localize_script('cookie-consent-king-js', 'cckTranslations', $translations);
 
-    $css_files = glob($asset_path . '*.css');
-    if ($css_files) {
-        $css_file = basename($css_files[0]);
-        wp_enqueue_style(
-            'cookie-consent-king-css',
-            plugin_dir_url(__FILE__) . 'dist/assets/' . $css_file,
-            [],
-            COOKIE_CONSENT_KING_VERSION
-        );
-    }
+    wp_enqueue_style(
+        'cookie-consent-king-css',
+        $asset_url . 'index.css',
+        [],
+        filemtime($css_path)
+    );
 }
 add_action('wp_enqueue_scripts', 'cck_enqueue_assets');
 


### PR DESCRIPTION
## Summary
- verify dist/assets/index.js and index.css exist before enqueueing
- warn admin via wp_admin_notice if build assets are missing
- use filemtime for script and style versioning and update docs

## Testing
- `php -l cookie-consent-king.php`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; Parsing error: Merge conflict marker encountered)*
- `npm test` *(fails: Transform failed with 1 error: Unexpected "===" in cookieManager.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688f818169e8833097837bba6c10616b