### PR TITLE
Set default options on activation and cleanup on deactivation

### DIFF
--- a/cookie-consent-king.php
+++ b/cookie-consent-king.php
@@ -123,12 +123,24 @@ function cck_load_textdomain() {
 add_action('init', 'cck_load_textdomain');
 
 function cck_activate() {
-    // Placeholder for activation logic.
+    $defaults = [
+        'cck_banner_heading' => __('Gestión de Cookies', 'cookie-consent-king'),
+        'cck_banner_message' => __('Utilizamos cookies para mejorar tu experiencia de navegación.', 'cookie-consent-king'),
+        'cck_policy_url'     => '/politica-de-cookies',
+    ];
+
+    foreach ($defaults as $option => $value) {
+        if (false === get_option($option)) {
+            add_option($option, $value);
+        }
+    }
 }
 register_activation_hook(__FILE__, 'cck_activate');
 
 function cck_deactivate() {
-    // Placeholder for deactivation logic.
+    delete_option('cck_banner_heading');
+    delete_option('cck_banner_message');
+    delete_option('cck_policy_url');
 }
 register_deactivation_hook(__FILE__, 'cck_deactivate');
 

--- a/src/utils/__tests__/cookieManager.test.ts
+++ b/src/utils/__tests__/cookieManager.test.ts
@@ -55,9 +55,6 @@ const sampleConsent = {
       cookieManager.updateConsent(sampleConsent);
       expect(listener).toHaveBeenCalledTimes(1);
     });
-  });
-
-=======
 
   it('onConsentChange notifies listeners and allows unsubscribe', () => {
     const listener = vi.fn();

--- a/src/utils/cookieManager.ts
+++ b/src/utils/cookieManager.ts
@@ -8,6 +8,7 @@ export type { ConsentSettings } from '@/types/consent';
 
 export interface CookieManagerConfig {
   gtmId?: string;
+  position?: string;
 }
 
 type DataLayerEvent = Record<string, unknown>;
@@ -218,6 +219,10 @@ export class CookieManager {
     if (newConfig.gtmId) {
       this.loadGtmScript();
     }
+  }
+
+  public updateConfig(newConfig: Partial<CookieManagerConfig>): void {
+    this.setConfig(newConfig);
   }
 
   public getConfig(): CookieManagerConfig {


### PR DESCRIPTION
## Summary
- Initialize default banner texts and policy URL during plugin activation using `add_option` and clean them up on deactivation.
- Expand CookieManager configuration with position support and `updateConfig` method for test coverage.
- Resolve test suite issues in cookieManager tests.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f817d674c83308ffcb12f015ab329