### PR TITLE
chore: update plugin version constant

### DIFF
--- a/cookie-consent-king.php
+++ b/cookie-consent-king.php
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('COOKIE_CONSENT_KING_VERSION')) {
-    define('COOKIE_CONSENT_KING_VERSION', '1.0.0');
+    define('COOKIE_CONSENT_KING_VERSION', '2.0');
 }
 
 function cck_enqueue_assets() {


### PR DESCRIPTION
## Summary
- sync `COOKIE_CONSENT_KING_VERSION` constant with plugin header version

## Testing
- `npm test` *(fails: Transform failed with unexpected === in cookieManager.test.ts)*
- `npm run lint` *(fails: various lint errors including merge conflict marker)*

------
https://chatgpt.com/codex/tasks/task_e_688f8176309883308edb36642f81cd70