### PR TITLE
Fix asset enqueue function

### DIFF
--- a/cookie-consent-king.php
+++ b/cookie-consent-king.php
@@ -109,15 +109,13 @@ function cck_enqueue_assets() {
 
         wp_localize_script('cookie-consent-king-js', 'cckTranslations', $translations);
         add_action('wp_footer', 'cck_render_root_div');
-    }
 
-
-    wp_enqueue_style(
-        'cookie-consent-king-css',
-        $asset_url . 'index.css',
-        [],
-        filemtime($css_path)
-    );
+        wp_enqueue_style(
+            'cookie-consent-king-css',
+            $asset_url . 'index.css',
+            [],
+            filemtime($css_path)
+        );
 }
 
 function cck_render_root_div() {


### PR DESCRIPTION
## Summary
- remove stray brace in cck_enqueue_assets and move style enqueue inside

## Testing
- `php -l cookie-consent-king.php`
- `npm test`
- `npm run lint` *(fails: 3 errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_688f8b1b13588330981170fe89e599d7