### PR TITLE
Handle admin notice for missing assets

### DIFF
--- a/cookie-consent-king.php
+++ b/cookie-consent-king.php
@@ -26,10 +26,16 @@ function cck_enqueue_assets() {
     $css_path = $asset_path . 'index.css';
 
     if (!file_exists($js_path) || !file_exists($css_path)) {
-        wp_admin_notice(
-            __('Cookie Consent King: assets not found. Please run "npm run build".', 'cookie-consent-king'),
-            ['type' => 'error']
-        );
+        $message = __('Cookie Consent King: assets not found. Please run "npm run build".', 'cookie-consent-king');
+
+        if (function_exists('wp_admin_notice')) {
+            wp_admin_notice($message, ['type' => 'error']);
+        } else {
+            add_action('admin_notices', function () use ($message) {
+                echo '<div class="notice notice-error"><p>' . esc_html($message) . '</p></div>';
+            });
+        }
+
         return;
     }
 
@@ -109,7 +115,6 @@ function cck_enqueue_assets() {
 
         wp_localize_script('cookie-consent-king-js', 'cckTranslations', $translations);
         add_action('wp_footer', 'cck_render_root_div');
-    }
 
 
     wp_enqueue_style(


### PR DESCRIPTION
## Summary
- ensure missing asset notice works across WordPress versions
- fix syntax error in cck_enqueue_assets

## Testing
- `php -l cookie-consent-king.php`
- `npm test`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype @typescript-eslint/no-empty-object-type)*
- custom PHP script emulating old WordPress


------
https://chatgpt.com/codex/tasks/task_e_688f8b1b8bf883308db73a2a4b9576e1