### PR TITLE
Add sanitization callbacks for settings

### DIFF
--- a/cookie-consent-king.php
+++ b/cookie-consent-king.php
@@ -239,7 +239,13 @@ add_action('admin_menu', 'cck_register_admin_menu');
 
 function cck_settings_init() {
     // Banner Styles options.
-    register_setting('cck_banner_styles_group', 'cck_banner_styles_options');
+    register_setting(
+        'cck_banner_styles_group',
+        'cck_banner_styles_options',
+        [
+            'sanitize_callback' => 'cck_sanitize_banner_styles',
+        ]
+    );
     add_settings_section('cck_banner_styles_section', '', '__return_false', 'cck-banner-styles');
     add_settings_field(
         'cck_banner_bg_color',
@@ -257,7 +263,13 @@ function cck_settings_init() {
     );
 
     // Default Texts options.
-    register_setting('cck_default_texts_group', 'cck_default_texts_options');
+    register_setting(
+        'cck_default_texts_group',
+        'cck_default_texts_options',
+        [
+            'sanitize_callback' => 'cck_sanitize_default_texts',
+        ]
+    );
     add_settings_section('cck_default_texts_section', '', '__return_false', 'cck-default-texts');
     add_settings_field(
         'cck_default_title',
@@ -275,7 +287,13 @@ function cck_settings_init() {
     );
 
     // Basic Configuration options.
-    register_setting('cck_basic_configuration_group', 'cck_basic_configuration_options');
+    register_setting(
+        'cck_basic_configuration_group',
+        'cck_basic_configuration_options',
+        [
+            'sanitize_callback' => 'cck_sanitize_basic_configuration',
+        ]
+    );
     add_settings_section('cck_basic_configuration_section', '', '__return_false', 'cck-basic-configuration');
     add_settings_field(
         'cck_privacy_url',
@@ -286,7 +304,13 @@ function cck_settings_init() {
     );
 
     // Cookie List options.
-    register_setting('cck_cookie_list_group', 'cck_cookie_list_options');
+    register_setting(
+        'cck_cookie_list_group',
+        'cck_cookie_list_options',
+        [
+            'sanitize_callback' => 'cck_sanitize_cookie_list',
+        ]
+    );
     add_settings_section('cck_cookie_list_section', '', '__return_false', 'cck-cookie-list');
     add_settings_field(
         'cck_cookie_list',
@@ -338,6 +362,36 @@ function cck_field_cookie_list() {
     echo '<textarea name="cck_cookie_list_options[list]" rows="5" cols="50">' . esc_textarea($value) . '</textarea>';
 }
 
+// -----------------------------------------------------------------------------
+// Sanitize callbacks
+// -----------------------------------------------------------------------------
+
+function cck_sanitize_banner_styles($input) {
+    $output = [];
+    $output['bg_color']   = sanitize_hex_color($input['bg_color'] ?? '');
+    $output['text_color'] = sanitize_hex_color($input['text_color'] ?? '');
+    return $output;
+}
+
+function cck_sanitize_default_texts($input) {
+    $output = [];
+    $output['title']   = sanitize_text_field($input['title'] ?? '');
+    $output['message'] = sanitize_textarea_field($input['message'] ?? '');
+    return $output;
+}
+
+function cck_sanitize_basic_configuration($input) {
+    $output = [];
+    $output['privacy_url'] = esc_url_raw($input['privacy_url'] ?? '');
+    return $output;
+}
+
+function cck_sanitize_cookie_list($input) {
+    $output = [];
+    $output['list'] = sanitize_textarea_field($input['list'] ?? '');
+    return $output;
+}
+
 /**
  * Render the Dashboard screen.
  */
@@ -356,8 +410,8 @@ function cck_render_banner_styles() {
     ) {
         $input   = $_POST['cck_banner_styles_options'] ?? [];
         $options = [
-            'bg_color'   => sanitize_text_field($input['bg_color'] ?? ''),
-            'text_color' => sanitize_text_field($input['text_color'] ?? ''),
+            'bg_color'   => sanitize_hex_color($input['bg_color'] ?? ''),
+            'text_color' => sanitize_hex_color($input['text_color'] ?? ''),
         ];
         update_option('cck_banner_styles_options', $options);
         echo '<div class="updated"><p>' . esc_html__('Settings saved.', 'cookie-consent-king') . '</p></div>';


### PR DESCRIPTION
## Summary
- sanitize banner, default text, configuration, and cookie list options
- centralize sanitization logic in dedicated callbacks
- validate banner color values using `sanitize_hex_color`

## Testing
- `php -l cookie-consent-king.php`
- `npm test`
- `npm run lint` *(fails: no-empty-object-type, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_688f944df13c833083fe8f20698f4fbb