### PR TITLE
refactor: centralize consent management

### DIFF
--- a/src/utils/cookieManager.ts
+++ b/src/utils/cookieManager.ts
@@ -33,7 +33,7 @@ export class CookieManager {
 
   private constructor(config: CookieManagerConfig = {}) {
     this.config = { ...config };
-    this.loadSavedConsent();
+    this.loadConsent();
   }
 
   public static getInstance(config?: CookieManagerConfig): CookieManager {
@@ -45,16 +45,19 @@ export class CookieManager {
     return CookieManager.instance;
   }
 
-  private loadSavedConsent(): void {
+  public loadConsent(): ConsentSettings | null {
     try {
       const savedConsent = localStorage.getItem('cookieConsent');
       if (savedConsent) {
         this.consent = JSON.parse(savedConsent);
         this.updateGoogleConsentMode(this.consent!);
+        return this.consent;
       }
+      this.initializeConsentMode();
     } catch (error) {
       console.error('Error loading saved consent:', error);
     }
+    return null;
   }
 
   public getConsent(): ConsentSettings | null {
@@ -69,7 +72,7 @@ export class CookieManager {
     return this.consent ? this.consent[type] : false;
   }
 
-  public updateConsent(newConsent: ConsentSettings, action: string = 'custom'): void {
+  public saveConsent(newConsent: ConsentSettings, action: string = 'custom'): void {
     this.consent = newConsent;
 
     if (typeof window !== 'undefined') {
@@ -127,7 +130,7 @@ export class CookieManager {
     this.listeners = [];
   }
 
-  public onConsentChange(listener: (consent: ConsentSettings) => void): () => void {
+  public onChange(listener: (consent: ConsentSettings) => void): () => void {
     this.listeners.push(listener);
     
     // Devolver función para desuscribirse


### PR DESCRIPTION
## Summary
- expose loadConsent, saveConsent, resetConsent and onChange in cookieManager
- refactor CookieBanner to use cookieManager API
- update unit tests for new consent manager methods

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68c1af7a69b08330b28ae4bac4c6810b