### PR TITLE
feat: manage consent via cookies and unify storage access

### DIFF
--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
@@ -10,6 +10,7 @@ import { Label } from '@/components/ui/label';
 import { Cookie, Settings, Shield, BarChart3, Target, X } from 'lucide-react';
 import { t } from '@/utils/i18n';
 import type { ConsentSettings } from '@/types/consent';
+import { cookieManager } from '@/utils/cookieManager';
 
 interface CookieBannerProps {
   onConsentUpdate?: (consent: ConsentSettings) => void;
@@ -19,27 +20,10 @@ interface CookieBannerProps {
 }
 
 // Consent Mode v2 integration
-interface Gtag {
-  (
-    command: 'consent' | 'config' | 'event',
-    action: string,
-    params?: Record<string, unknown>
-  ): void;
-  (...args: unknown[]): void;
-}
-
-type DataLayerEvent = Record<string, unknown>;
-
-interface DataLayer extends Array<DataLayerEvent> {
-  push: (...args: DataLayerEvent[]) => number;
-}
-
 declare global {
   interface Window {
-
     gtag?: (...args: unknown[]) => void;
-    dataLayer?: DataLayer;
-
+    dataLayer?: unknown[];
   }
 }
 
@@ -67,168 +51,27 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
   }, []);
 
   useEffect(() => {
-    // Check if user has already made a choice
-    let savedConsent: string | null = null;
-
-    if (typeof window !== 'undefined' && window.localStorage) {
-      try {
-        savedConsent = window.localStorage.getItem('cookieConsent');
-      } catch (error) {
-        if (import.meta.env.DEV) {
-          console.error('CookieBanner: Error accessing localStorage', error);
-        }
-      }
-    }
-
-    if (import.meta.env.DEV) {
-      console.log('CookieBanner: checking saved consent', savedConsent);
-    }
+    const savedConsent = cookieManager.getConsent();
 
     if (!savedConsent) {
-      if (import.meta.env.DEV) {
-        console.log('CookieBanner: No saved consent, showing banner');
-      }
       setShowBanner(true);
       setShowMiniBanner(false);
-      // Initialize Google Consent Mode v2 with default values
-      initializeConsentMode();
+      cookieManager.initializeConsentMode();
     } else {
-      if (import.meta.env.DEV) {
-        console.log('CookieBanner: Found saved consent, parsing and applying');
-      }
-      try {
-        const parsedConsent = JSON.parse(savedConsent);
-        setConsent(parsedConsent);
-        updateConsentMode(parsedConsent);
-        setShowBanner(false);
-        setShowMiniBanner(true); // Show mini banner when consent exists
-      } catch (error) {
-        if (import.meta.env.DEV) {
-          console.error('CookieBanner: Error parsing saved consent', error);
-        }
-        if (typeof window !== 'undefined' && window.localStorage) {
-          try {
-            window.localStorage.removeItem('cookieConsent');
-            window.localStorage.removeItem('cookieConsentDate');
-          } catch (cleanupError) {
-            if (import.meta.env.DEV) {
-              console.error('CookieBanner: Error cleaning corrupt consent', cleanupError);
-            }
-          }
-        }
-        setConsent({
-          necessary: true,
-          analytics: false,
-          marketing: false,
-          preferences: false,
-        });
-        setShowBanner(true);
-        setShowMiniBanner(false);
-        initializeConsentMode();
-      }
+      setConsent(savedConsent);
+      setShowBanner(false);
+      setShowMiniBanner(true);
+      onConsentUpdate?.(savedConsent);
     }
-  }, [updateConsentMode]);
-
-  const initializeConsentMode = () => {
-    if (typeof window !== 'undefined' && window.gtag) {
-      // Set default consent state (denied)
-      window.gtag('consent', 'default', {
-        'ad_storage': 'denied',
-        'ad_user_data': 'denied',
-        'ad_personalization': 'denied',
-        'analytics_storage': 'denied',
-        'functionality_storage': 'denied',
-        'personalization_storage': 'denied',
-        'security_storage': 'granted', // Usually granted by default
-        'wait_for_update': 500,
-      });
-    }
-  };
-
-  const getConsentAction = (consentSettings: ConsentSettings): string => {
-    const { analytics, marketing, preferences } = consentSettings;
-    
-    if (analytics && marketing && preferences) {
-      return 'accept_all';
-    } else if (!analytics && !marketing && !preferences) {
-      return 'reject_all';
-    } else {
-      return 'custom_selection';
-    }
-  };
-
-  const pushDataLayerEvent = (consentSettings: ConsentSettings, action: string) => {
-    // Ensure dataLayer exists
-    if (typeof window !== 'undefined') {
-      window.dataLayer = window.dataLayer || [];
-      
-      const eventData = {
-        'event': 'consent_update',
-        'consent': {
-          'ad_storage': consentSettings.marketing ? 'granted' : 'denied',
-          'analytics_storage': consentSettings.analytics ? 'granted' : 'denied',
-          'functionality_storage': consentSettings.preferences ? 'granted' : 'denied',
-          'personalization_storage': consentSettings.preferences ? 'granted' : 'denied',
-          'security_storage': 'granted', // Always granted
-          'ad_user_data': consentSettings.marketing ? 'granted' : 'denied',
-          'ad_personalization': consentSettings.marketing ? 'granted' : 'denied'
-        },
-        'consent_action': action,
-        'timestamp': new Date().toISOString()
-      };
-
-      if (import.meta.env.DEV) {
-        console.log('Pushing to dataLayer:', eventData);
-      }
-      window.dataLayer.push(eventData);
-    }
-  };
-
-  const updateConsentMode = useCallback(
-    (consentSettings: ConsentSettings, action?: string) => {
-      if (typeof window !== 'undefined' && window.gtag) {
-        window.gtag('consent', 'update', {
-          'ad_storage': consentSettings.marketing ? 'granted' : 'denied',
-          'ad_user_data': consentSettings.marketing ? 'granted' : 'denied',
-          'ad_personalization': consentSettings.marketing ? 'granted' : 'denied',
-          'analytics_storage': consentSettings.analytics ? 'granted' : 'denied',
-          'functionality_storage': consentSettings.preferences ? 'granted' : 'denied',
-          'personalization_storage': consentSettings.preferences ? 'granted' : 'denied',
-        });
-      }
-
-      // Push consent_update event to dataLayer
-      if (action) {
-        pushDataLayerEvent(consentSettings, action);
-      }
-
-      onConsentUpdate?.(consentSettings);
-    },
-    [onConsentUpdate]
-  );
+  }, [onConsentUpdate]);
 
   const saveConsent = (consentSettings: ConsentSettings, action: string) => {
     if (import.meta.env.DEV) {
       console.log('Saving consent:', consentSettings, 'Action:', action);
     }
-    if (typeof window !== 'undefined' && window.localStorage) {
-      try {
-        window.localStorage.setItem('cookieConsent', JSON.stringify(consentSettings));
-        window.localStorage.setItem('cookieConsentDate', new Date().toISOString());
-      } catch (error) {
-        if (import.meta.env.DEV) {
-          console.error('CookieBanner: Error saving consent', error);
-        }
-      }
-    }
 
-    if (typeof window !== 'undefined') {
-      // Dispatch custom event to notify other components
-      window.dispatchEvent(new CustomEvent('consentUpdated', { detail: consentSettings }));
-    }
-
-    // Update consent mode and push dataLayer event
-    updateConsentMode(consentSettings, action);
+    cookieManager.updateConsent(consentSettings, action);
+    onConsentUpdate?.(consentSettings);
 
     setConsent(consentSettings);
     setShowBanner(false);

--- a/src/utils/__tests__/cookieManager.test.ts
+++ b/src/utils/__tests__/cookieManager.test.ts
@@ -22,6 +22,9 @@ const sampleConsent = {
     expect(cookieManager.getConsent()).toEqual(sampleConsent);
     expect(localStorage.getItem('cookieConsent')).toEqual(JSON.stringify(sampleConsent));
     expect(localStorage.getItem('cookieConsentDate')).not.toBeNull();
+    const cookieMatch = document.cookie.match(/cookieConsent=([^;]+)/);
+    expect(cookieMatch).not.toBeNull();
+    expect(JSON.parse(decodeURIComponent(cookieMatch![1]))).toEqual(sampleConsent);
     expect(handler).toHaveBeenCalled();
     window.removeEventListener('consentUpdated', handler);
   });
@@ -35,6 +38,7 @@ const sampleConsent = {
     expect(cookieManager.getConsent()).toBeNull();
     expect(localStorage.getItem('cookieConsent')).toBeNull();
     expect(localStorage.getItem('cookieConsentDate')).toBeNull();
+    expect(document.cookie).not.toContain('cookieConsent=');
     expect(handler).toHaveBeenCalled();
       window.removeEventListener('consentReset', handler);
     });
@@ -130,6 +134,15 @@ const sampleConsent = {
 
     cookieManager.resetConsent();
     expect(cookieManager.getConsentDate()).toBeNull();
+  });
+
+  it('loads consent from cookie when localStorage is empty', () => {
+    cookieManager.resetConsent();
+    localStorage.clear();
+    document.cookie = `cookieConsent=${encodeURIComponent(JSON.stringify(sampleConsent))}; path=/; max-age=31536000`;
+    // @ts-expect-error accessing private method for test
+    cookieManager.loadSavedConsent();
+    expect(cookieManager.getConsent()).toEqual(sampleConsent);
   });
 });
 

--- a/src/utils/cookieManager.ts
+++ b/src/utils/cookieManager.ts
@@ -47,7 +47,19 @@ export class CookieManager {
 
   private loadSavedConsent(): void {
     try {
-      const savedConsent = localStorage.getItem('cookieConsent');
+      let savedConsent: string | null = null;
+
+      if (typeof document !== 'undefined') {
+        const match = document.cookie.match(/(?:^|; )cookieConsent=([^;]+)/);
+        if (match) {
+          savedConsent = decodeURIComponent(match[1]);
+        }
+      }
+
+      if (!savedConsent && typeof localStorage !== 'undefined') {
+        savedConsent = localStorage.getItem('cookieConsent');
+      }
+
       if (savedConsent) {
         this.consent = JSON.parse(savedConsent);
         this.updateGoogleConsentMode(this.consent!);
@@ -81,6 +93,11 @@ export class CookieManager {
       }
     }
 
+    if (typeof document !== 'undefined') {
+      const cookieValue = encodeURIComponent(JSON.stringify(newConsent));
+      document.cookie = `cookieConsent=${cookieValue}; path=/; max-age=31536000`;
+    }
+
     // Actualizar Google Consent Mode
     this.updateGoogleConsentMode(newConsent);
 
@@ -99,9 +116,11 @@ export class CookieManager {
   }
 
   public resetConsent(): void {
-
     localStorage.removeItem('cookieConsent');
     localStorage.removeItem('cookieConsentDate');
+    if (typeof document !== 'undefined') {
+      document.cookie = 'cookieConsent=; path=/; max-age=0';
+    }
     const resetConsent: ConsentSettings = {
       necessary: false,
       analytics: false,


### PR DESCRIPTION
## Summary
- persist consent in cookies and handle removal on reset
- use cookieManager in CookieBanner instead of direct localStorage
- test cookie creation and loading

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68c1af7a66b4833094d2e280b3ef6ec2