### PR TITLE
feat: expose backend options in consent banner

### DIFF
--- a/cookie-consent-king.php
+++ b/cookie-consent-king.php
@@ -116,7 +116,21 @@ function cck_enqueue_assets() {
             'Cookies de marketing' => __('Cookies de marketing', 'cookie-consent-king'),
         ];
 
-        wp_localize_script('cookie-consent-king-js', 'cckTranslations', $translations);
+        $banner_styles  = get_option('cck_banner_styles_options', []);
+        $default_texts  = get_option('cck_default_texts_options', []);
+        $basic_config   = get_option('cck_basic_configuration_options', []);
+
+        $localized_data = [
+            'translations' => $translations,
+            'styles'       => $banner_styles,
+            'texts'        => $default_texts,
+            'urls'         => [
+                'cookiePolicy' => $basic_config['privacy_url'] ?? '',
+                'aboutCookies' => $basic_config['about_cookies_url'] ?? '',
+            ],
+        ];
+
+        wp_localize_script('cookie-consent-king-js', 'cckData', $localized_data);
         add_action('wp_footer', 'cck_render_root_div');
 
         wp_enqueue_style(

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -55,6 +55,20 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
     preferences: false,
   });
 
+  const cckData =
+    typeof window !== 'undefined' ? ((window as any).cckData || {}) : {};
+  const { styles = {}, texts = {}, urls = {} } = cckData;
+  const bannerStyle: React.CSSProperties = {
+    backgroundColor: styles.bg_color || undefined,
+    color: styles.text_color || undefined,
+  };
+  const heading = texts.title || t('Gestión de Cookies');
+  const defaultMessage =
+    'Utilizamos cookies para mejorar tu experiencia de navegación, personalizar contenido y anuncios, proporcionar funciones de redes sociales y analizar nuestro tráfico. También compartimos información sobre tu uso de nuestro sitio con nuestros socios de análisis y publicidad.';
+  const message = texts.message || t(defaultMessage);
+  const cookiePolicyUrlResolved = urls.cookiePolicy || cookiePolicyUrl;
+  const aboutCookiesUrlResolved = urls.aboutCookies || aboutCookiesUrl;
+
   useEffect(() => {
     const handleResize = () => {
       if (typeof window !== 'undefined') {
@@ -281,7 +295,7 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
     <>
       {showBanner && (!isMobile || showSettings) && (
         <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-end justify-center p-4">
-          <Card className="w-full max-w-2xl bg-cookie-banner border-cookie-banner-border shadow-floating animate-in slide-in-from-bottom-4 duration-300">
+          <Card className="w-full max-w-2xl bg-cookie-banner border-cookie-banner-border shadow-floating animate-in slide-in-from-bottom-4 duration-300" style={bannerStyle}>
             <div className="p-6">
                 {!showSettings ? (
                   // Main banner
@@ -293,10 +307,10 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
                       <div className="flex-1 space-y-3">
                         <div>
                           <h3 className="text-lg font-semibold text-foreground mb-2">
-                            {t('Gestión de Cookies')}
+                            {heading}
                           </h3>
                           <p className="text-sm text-muted-foreground leading-relaxed">
-                            {t('Utilizamos cookies para mejorar tu experiencia de navegación, personalizar contenido y anuncios, proporcionar funciones de redes sociales y analizar nuestro tráfico. También compartimos información sobre tu uso de nuestro sitio con nuestros socios de análisis y publicidad.')}
+                            {message}
                           </p>
                         </div>
                       </div>
@@ -366,11 +380,11 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
                           </p>
                           <p className="text-sm text-muted-foreground">
                             {t('Puedes aceptar todas las cookies pulsando el botón "Aceptar", rechazar todas las cookies pulsando sobre el botón "Rechazar" o configurarlas su uso pulsando el botón "Configuración de cookies".')}
-                            {cookiePolicyUrl && (
+                            {cookiePolicyUrlResolved && (
                               <>
                                 {t('Si deseas más información pulsa en')}{' '}
                                 <a
-                                  href={cookiePolicyUrl}
+                                  href={cookiePolicyUrlResolved}
                                   target="_blank"
                                   rel="noopener noreferrer"
                                   className="text-primary hover:underline font-medium"
@@ -545,23 +559,23 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
                           <p>
                             {t('En cumplimiento del Reglamento General de Protección de Datos (RGPD), solicitamos su consentimiento para el uso de cookies no esenciales. Puede gestionar sus preferencias de cookies en cualquier momento accediendo a la configuración de privacidad de nuestro sitio web.')}
                           </p>
-                          <p>
-                            {t('Para más información sobre nuestra política de privacidad y el tratamiento de datos personales, consulte nuestra política de privacidad completa.')}
-                            {aboutCookiesUrl && (
-                              <>
-                                {' '}{t('Para información detallada sobre cookies, visite')}{' '}
-                                <a
-                                  href={aboutCookiesUrl}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="text-primary hover:underline font-medium"
-                                >
-                                  {t('Acerca de las Cookies')}
-                                </a>
-                                .
-                              </>
-                            )}
-                          </p>
+                            <p>
+                              {t('Para más información sobre nuestra política de privacidad y el tratamiento de datos personales, consulte nuestra política de privacidad completa.')}
+                              {aboutCookiesUrlResolved && (
+                                <>
+                                  {' '}{t('Para información detallada sobre cookies, visite')}{' '}
+                                  <a
+                                    href={aboutCookiesUrlResolved}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-primary hover:underline font-medium"
+                                  >
+                                    {t('Acerca de las Cookies')}
+                                  </a>
+                                  .
+                                </>
+                              )}
+                            </p>
                         </div>
 
                         <Separator />
@@ -594,12 +608,12 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
 
       {showBanner && isMobile && !showSettings && (
           <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-full px-4">
-            <Card className="bg-cookie-banner border-cookie-banner-border shadow-floating animate-in slide-in-from-bottom-4 duration-300">
+            <Card className="bg-cookie-banner border-cookie-banner-border shadow-floating animate-in slide-in-from-bottom-4 duration-300" style={bannerStyle}>
               <div className="p-4 space-y-3">
                 <div className="flex items-center gap-2">
                   <Cookie className="w-5 h-5 text-primary" />
                   <p className="text-sm flex-1">
-                    {t('Utilizamos cookies para mejorar tu experiencia')}
+                    {message}
                   </p>
                 </div>
                 <div className="flex gap-2 justify-end">
@@ -617,7 +631,7 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
 
       {!forceShow && !showBanner && showMiniBanner && (
         <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] w-full max-w-xs px-4">
-          <Card className="bg-cookie-banner border-cookie-banner-border shadow-floating animate-in slide-in-from-bottom-4 duration-300">
+          <Card className="bg-cookie-banner border-cookie-banner-border shadow-floating animate-in slide-in-from-bottom-4 duration-300" style={bannerStyle}>
             <div className="flex items-center justify-between p-3">
               <div className="flex items-center gap-2">
                 <Cookie className="w-5 h-5 text-primary" />

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,8 +1,7 @@
 export const t = (key: string): string => {
   if (typeof window !== 'undefined') {
-    const translations = (window as Window).cckTranslations as
-      | Record<string, string>
-      | undefined;
+    const data = (window as Window & { cckData?: { translations?: Record<string, string> } }).cckData;
+    const translations = data?.translations;
     if (translations && translations[key]) {
       return translations[key];
     }


### PR DESCRIPTION
## Summary
- localize banner style, text, and URL options with translations
- consume localized options in CookieBanner UI
- read translations from combined localization object

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c1b09859ec8330a5c1d5748223c716