### PR TITLE
Add forced cookie banner preview on admin pages

### DIFF
--- a/cookie-consent-king.php
+++ b/cookie-consent-king.php
@@ -132,6 +132,26 @@ function cck_render_root_div() {
 }
 add_action('wp_enqueue_scripts', 'cck_enqueue_assets');
 
+function cck_enqueue_admin_preview_assets($hook) {
+    if (strpos($hook, 'cck') === false) {
+        return;
+    }
+
+    cck_enqueue_assets();
+
+    $default_texts = get_option('cck_default_texts_options', []);
+    $basic_config = get_option('cck_basic_configuration_options', []);
+    $options = [
+        'title' => $default_texts['title'] ?? '',
+        'message' => $default_texts['message'] ?? '',
+        'cookiePolicyUrl' => $basic_config['privacy_url'] ?? '',
+    ];
+
+    wp_localize_script('cookie-consent-king-js', 'cckOptions', $options);
+    wp_add_inline_script('cookie-consent-king-js', 'window.cckPreview = true; window.cckForceShow = true;', 'before');
+}
+add_action('admin_enqueue_scripts', 'cck_enqueue_admin_preview_assets');
+
 function cck_load_textdomain() {
     load_plugin_textdomain(
         'cookie-consent-king',
@@ -368,7 +388,10 @@ function cck_render_banner_styles() {
     wp_nonce_field('cck_save_banner_styles', 'cck_banner_styles_nonce');
     do_settings_sections('cck-banner-styles');
     submit_button();
-    echo '</form></div>';
+    echo '</form>';
+    echo '<h2>' . esc_html__('Preview', 'cookie-consent-king') . '</h2>';
+    cck_render_preview_banner();
+    echo '</div>';
 }
 
 /**
@@ -394,7 +417,10 @@ function cck_render_default_texts() {
     wp_nonce_field('cck_save_default_texts', 'cck_default_texts_nonce');
     do_settings_sections('cck-default-texts');
     submit_button();
-    echo '</form></div>';
+    echo '</form>';
+    echo '<h2>' . esc_html__('Preview', 'cookie-consent-king') . '</h2>';
+    cck_render_preview_banner();
+    echo '</div>';
 }
 
 /**
@@ -419,7 +445,10 @@ function cck_render_basic_configuration() {
     wp_nonce_field('cck_save_basic_configuration', 'cck_basic_configuration_nonce');
     do_settings_sections('cck-basic-configuration');
     submit_button();
-    echo '</form></div>';
+    echo '</form>';
+    echo '<h2>' . esc_html__('Preview', 'cookie-consent-king') . '</h2>';
+    cck_render_preview_banner();
+    echo '</div>';
 }
 
 /**
@@ -444,7 +473,15 @@ function cck_render_cookie_list() {
     wp_nonce_field('cck_save_cookie_list', 'cck_cookie_list_nonce');
     do_settings_sections('cck-cookie-list');
     submit_button();
-    echo '</form></div>';
+    echo '</form>';
+    echo '<h2>' . esc_html__('Preview', 'cookie-consent-king') . '</h2>';
+    cck_render_preview_banner();
+    echo '</div>';
 }
+
+function cck_render_preview_banner() {
+    echo '<div id="root"></div>';
+}
+add_shortcode('cck_preview_banner', 'cck_render_preview_banner');
 
 ?>

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -16,6 +16,8 @@ interface CookieBannerProps {
   forceShow?: boolean; // Nueva prop para forzar mostrar el banner en demo
   cookiePolicyUrl?: string; // URL personalizable para la política de cookies
   aboutCookiesUrl?: string; // URL personalizable para información detallada sobre cookies
+  title?: string; // Título personalizado del banner
+  message?: string; // Mensaje personalizado del banner
 }
 
 // Consent Mode v2 integration
@@ -43,7 +45,7 @@ declare global {
   }
 }
 
-const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow = false, cookiePolicyUrl, aboutCookiesUrl }) => {
+const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow = false, cookiePolicyUrl, aboutCookiesUrl, title, message }) => {
   const [showBanner, setShowBanner] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showMiniBanner, setShowMiniBanner] = useState(false);
@@ -293,10 +295,10 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
                       <div className="flex-1 space-y-3">
                         <div>
                           <h3 className="text-lg font-semibold text-foreground mb-2">
-                            {t('Gestión de Cookies')}
+                            {title ?? t('Gestión de Cookies')}
                           </h3>
                           <p className="text-sm text-muted-foreground leading-relaxed">
-                            {t('Utilizamos cookies para mejorar tu experiencia de navegación, personalizar contenido y anuncios, proporcionar funciones de redes sociales y analizar nuestro tráfico. También compartimos información sobre tu uso de nuestro sitio con nuestros socios de análisis y publicidad.')}
+                            {message ?? t('Utilizamos cookies para mejorar tu experiencia de navegación, personalizar contenido y anuncios, proporcionar funciones de redes sociales y analizar nuestro tráfico. También compartimos información sobre tu uso de nuestro sitio con nuestros socios de análisis y publicidad.')}
                           </p>
                         </div>
                       </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,35 @@
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import CookieBanner from './components/CookieBanner';
+import './index.css';
 
-createRoot(document.getElementById("root")!).render(<App />);
+declare global {
+  interface Window {
+    cckPreview?: boolean;
+    cckForceShow?: boolean;
+    cckOptions?: {
+      title?: string;
+      message?: string;
+      cookiePolicyUrl?: string;
+      aboutCookiesUrl?: string;
+    };
+  }
+}
+
+const rootElement = document.getElementById('root')!;
+
+if (window.cckPreview) {
+  const opts = window.cckOptions || {};
+  createRoot(rootElement).render(
+    <CookieBanner
+      forceShow={window.cckForceShow ?? true}
+      cookiePolicyUrl={opts.cookiePolicyUrl}
+      aboutCookiesUrl={opts.aboutCookiesUrl}
+      title={opts.title}
+      message={opts.message}
+    />
+  );
+} else {
+  createRoot(rootElement).render(<App />);
+}
+


### PR DESCRIPTION
## Summary
- add `title` and `message` props to `CookieBanner` component
- render banner directly when `window.cckPreview` is set
- enqueue assets and show preview container on plugin settings pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b09bbb04833093aacda9845b4ef5