### PR TITLE
Add banner position option and frontend placement control

### DIFF
--- a/cookie-consent-king.php
+++ b/cookie-consent-king.php
@@ -116,6 +116,15 @@ function cck_enqueue_assets() {
             'Cookies de marketing' => __('Cookies de marketing', 'cookie-consent-king'),
         ];
 
+        $banner_styles = get_option('cck_banner_styles_options', []);
+        wp_localize_script(
+            'cookie-consent-king-js',
+            'cckBannerStyles',
+            [
+                'position' => $banner_styles['position'] ?? 'bottom',
+            ]
+        );
+
         wp_localize_script('cookie-consent-king-js', 'cckTranslations', $translations);
         add_action('wp_footer', 'cck_render_root_div');
 
@@ -255,6 +264,13 @@ function cck_settings_init() {
         'cck-banner-styles',
         'cck_banner_styles_section'
     );
+    add_settings_field(
+        'cck_banner_position',
+        __('Banner Position', 'cookie-consent-king'),
+        'cck_field_banner_position',
+        'cck-banner-styles',
+        'cck_banner_styles_section'
+    );
 
     // Default Texts options.
     register_setting('cck_default_texts_group', 'cck_default_texts_options');
@@ -314,6 +330,22 @@ function cck_field_banner_text_color() {
     echo '<input type="text" name="cck_banner_styles_options[text_color]" value="' . esc_attr($value) . '" />';
 }
 
+function cck_field_banner_position() {
+    $options  = get_option('cck_banner_styles_options', []);
+    $value    = $options['position'] ?? 'bottom';
+    $positions = [
+        'bottom' => __('Bottom', 'cookie-consent-king'),
+        'top'    => __('Top', 'cookie-consent-king'),
+        'modal'  => __('Modal', 'cookie-consent-king'),
+    ];
+    echo '<select name="cck_banner_styles_options[position]">';
+    foreach ($positions as $key => $label) {
+        $selected = selected($value, $key, false);
+        echo '<option value="' . esc_attr($key) . '" ' . $selected . '>' . esc_html($label) . '</option>';
+    }
+    echo '</select>';
+}
+
 function cck_field_default_title() {
     $options = get_option('cck_default_texts_options', []);
     $value   = $options['title'] ?? '';
@@ -355,9 +387,14 @@ function cck_render_banner_styles() {
         wp_verify_nonce($_POST['cck_banner_styles_nonce'], 'cck_save_banner_styles')
     ) {
         $input   = $_POST['cck_banner_styles_options'] ?? [];
+        $position = sanitize_text_field($input['position'] ?? 'bottom');
+        if (!in_array($position, ['bottom', 'top', 'modal'], true)) {
+            $position = 'bottom';
+        }
         $options = [
             'bg_color'   => sanitize_text_field($input['bg_color'] ?? ''),
             'text_color' => sanitize_text_field($input['text_color'] ?? ''),
+            'position'   => $position,
         ];
         update_option('cck_banner_styles_options', $options);
         echo '<div class="updated"><p>' . esc_html__('Settings saved.', 'cookie-consent-king') . '</p></div>';

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -55,6 +55,27 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
     preferences: false,
   });
 
+  const bannerPosition =
+    typeof window !== 'undefined'
+      ? (window as Window).cckBannerStyles?.position || 'bottom'
+      : 'bottom';
+
+  const overlayPositionClass =
+    bannerPosition === 'top'
+      ? 'items-start'
+      : bannerPosition === 'modal'
+        ? 'items-center'
+        : 'items-end';
+
+  const mobilePositionClass =
+    bannerPosition === 'top'
+      ? 'top-4'
+      : bannerPosition === 'modal'
+        ? 'top-1/2 -translate-y-1/2'
+        : 'bottom-4';
+
+  const miniBannerPositionClass = bannerPosition === 'top' ? 'top-6' : 'bottom-6';
+
   useEffect(() => {
     const handleResize = () => {
       if (typeof window !== 'undefined') {
@@ -280,7 +301,7 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
   return (
     <>
       {showBanner && (!isMobile || showSettings) && (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-end justify-center p-4">
+        <div className={`fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex justify-center p-4 ${overlayPositionClass}`}>
           <Card className="w-full max-w-2xl bg-cookie-banner border-cookie-banner-border shadow-floating animate-in slide-in-from-bottom-4 duration-300">
             <div className="p-6">
                 {!showSettings ? (
@@ -593,7 +614,7 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
       )}
 
       {showBanner && isMobile && !showSettings && (
-          <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-full px-4">
+          <div className={`fixed left-1/2 -translate-x-1/2 z-50 w-full px-4 ${mobilePositionClass}`}>
             <Card className="bg-cookie-banner border-cookie-banner-border shadow-floating animate-in slide-in-from-bottom-4 duration-300">
               <div className="p-4 space-y-3">
                 <div className="flex items-center gap-2">
@@ -616,7 +637,7 @@ const CookieBanner: React.FC<CookieBannerProps> = ({ onConsentUpdate, forceShow 
         )}
 
       {!forceShow && !showBanner && showMiniBanner && (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] w-full max-w-xs px-4">
+        <div className={`fixed left-1/2 -translate-x-1/2 z-[9999] w-full max-w-xs px-4 ${miniBannerPositionClass}`}>
           <Card className="bg-cookie-banner border-cookie-banner-border shadow-floating animate-in slide-in-from-bottom-4 duration-300">
             <div className="flex items-center justify-between p-3">
               <div className="flex items-center gap-2">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,4 +2,7 @@
 
 interface Window {
   cckTranslations?: Record<string, string>;
+  cckBannerStyles?: {
+    position?: string;
+  };
 }


### PR DESCRIPTION
## Summary
- allow selecting cookie banner position (bottom, top, modal) in plugin settings
- expose selected banner position to frontend with `wp_localize_script`
- adjust React banner component to position itself based on configured option

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b09d8f54833096441a5ae5157b70