### PR TITLE
chore: remove test tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "test": "vitest run"
+    "preview": "vite preview"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -79,8 +78,6 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1",
-    "vitest": "^1.5.0",
-    "jsdom": "^24.0.0"
+    "vite": "^5.4.1"
   }
 }


### PR DESCRIPTION
## Summary
- remove `vitest` test script and related dev dependencies

## Testing
- `npm install` *(fails: command not found)*
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b52ed5848330866dc47ce56fa44a