### PR TITLE
Add tabbed layout for consent banner

### DIFF
--- a/public/cck-banner.css
+++ b/public/cck-banner.css
@@ -2,7 +2,13 @@
 #cck-banner-backdrop.cck-visible { opacity: 1; pointer-events: all; }
 .cck-banner { position: fixed; bottom: 20px; left: 50%; width: calc(100% - 40px); max-width: 560px; background: var(--cck-bg-color); color: var(--cck-text-color); border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,0.2); z-index: 9999; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; overflow: hidden; transform: translate(-50%, 150%); transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1); }
 .cck-banner.cck-visible { transform: translate(-50%, 0); }
-.cck-main, .cck-settings { padding: 24px; }
+.cck-tab-nav { display: flex; border-bottom: 1px solid #e6e6e6; background: rgba(0, 0, 0, 0.02); }
+.cck-tab-btn { flex: 1; padding: 14px 16px; background: none; border: none; font-weight: 600; font-size: 14px; cursor: pointer; color: var(--cck-text-color); transition: background-color 0.2s ease, color 0.2s ease; }
+.cck-tab-btn:hover, .cck-tab-btn:focus { background-color: rgba(0, 0, 0, 0.06); outline: none; }
+.cck-tab-btn.cck-active { background: var(--cck-bg-color); color: var(--cck-primary-btn-bg); box-shadow: inset 0 -2px 0 var(--cck-primary-btn-bg); }
+.cck-tab-panels { padding: 24px; }
+.cck-tab-panel { display: none; }
+.cck-tab-panel.cck-active { display: block; }
 .cck-header { display: flex; align-items: flex-start; gap: 16px; }
 .cck-icon { width: 40px; height: 40px; flex-shrink: 0; }
 .cck-title { font-size: 18px; font-weight: 600; margin: 0 0 8px; color: var(--cck-text-color); }
@@ -12,10 +18,7 @@
 .cck-btn { padding: 10px 18px; border-radius: 8px; font-size: 14px; font-weight: 500; cursor: pointer; border: 1px solid transparent; transition: background-color 0.2s, color 0.2s, border-color 0.2s; }
 .cck-btn-primary { background: var(--cck-primary-btn-bg); color: var(--cck-primary-btn-text); }
 .cck-btn-secondary { background: transparent; color: var(--cck-text-color); border: 1px solid #e0e0e0; }
-.cck-settings { display: none; }
-.cck-settings-header { display: flex; justify-content: space-between; align-items: center; }
-.cck-settings-title { font-size: 18px; font-weight: 600; }
-.cck-close-btn { background: none; border: none; font-size: 24px; cursor: pointer; padding: 0; color: #888; }
+.cck-tab-description { font-size: 14px; line-height: 1.5; color: var(--cck-text-color); margin: 0 0 20px; }
 .cck-options { margin-top: 20px; display: flex; flex-direction: column; gap: 15px; }
 .cck-option { display: flex; justify-content: space-between; align-items: center; padding: 12px; border: 1px solid #eee; border-radius: 8px; }
 .cck-option label { font-weight: 500; }

--- a/public/cck-banner.js
+++ b/public/cck-banner.js
@@ -40,23 +40,33 @@ document.addEventListener('DOMContentLoaded', () => {
         bannerContainer.innerHTML = `
             <div id="cck-banner-backdrop"></div>
             <div id="cck-banner" class="cck-banner">
-                <div class="cck-main">
-                    <div class="cck-header">${iconHtml}<div class="cck-content"><h3 class="cck-title">${texts.title || ''}</h3><p class="cck-message">${texts.message || ''}</p></div></div>
-                    <div class="cck-actions">
-                        <button id="cck-personalize-btn" class="cck-btn cck-btn-secondary">${texts.personalize || 'Personalizar'}</button>
-                        <button id="cck-reject-btn" class="cck-btn cck-btn-primary">${texts.rejectAll || 'Rechazar todas'}</button>
-                        <button id="cck-accept-btn" class="cck-btn cck-btn-primary">${texts.acceptAll || 'Aceptar todas'}</button>
-                    </div>
+                <div class="cck-tab-nav" role="tablist">
+                    <button class="cck-tab-btn cck-active" data-tab="consent" role="tab" aria-selected="true">${texts.consentTab || 'Consentimiento'}</button>
+                    <button class="cck-tab-btn" data-tab="details" role="tab" aria-selected="false">${texts.detailsTab || 'Detalles'}</button>
+                    <button class="cck-tab-btn" data-tab="about" role="tab" aria-selected="false">${texts.aboutTab || 'Acerca de las cookies'}</button>
                 </div>
-                <div class="cck-settings">
-                    <div class="cck-settings-header"><h3 class="cck-settings-title">${texts.personalize || 'Personalizar'}</h3><button id="cck-close-btn" class="cck-close-btn">&times;</button></div>
-                    <div class="cck-options">
-                        <div class="cck-option"><label><strong>Necesario</strong> (Siempre activo)</label><label class="cck-switch"><input type="checkbox" data-consent="necessary" checked disabled><span class="cck-slider"></span></label></div>
-                        <div class="cck-option"><label>${texts.preferences || 'Preferencias'}</label><label class="cck-switch"><input type="checkbox" data-consent="preferences"><span class="cck-slider"></span></label></div>
-                        <div class="cck-option"><label>${texts.analytics || 'Análisis'}</label><label class="cck-switch"><input type="checkbox" data-consent="analytics"><span class="cck-slider"></span></label></div>
-                        <div class="cck-option"><label>${texts.marketing || 'Marketing'}</label><label class="cck-switch"><input type="checkbox" data-consent="marketing"><span class="cck-slider"></span></label></div>
-                    </div>
-                    <div class="cck-actions"><button id="cck-save-btn" class="cck-btn cck-btn-primary">${texts.savePreferences || 'Guardar preferencias'}</button></div>
+                <div class="cck-tab-panels">
+                    <section class="cck-tab-panel cck-active" data-tab-panel="consent" role="tabpanel">
+                        <div class="cck-header">${iconHtml}<div class="cck-content"><h3 class="cck-title">${texts.title || ''}</h3><p class="cck-message">${texts.message || ''}</p></div></div>
+                        <div class="cck-actions">
+                            <button id="cck-personalize-btn" class="cck-btn cck-btn-secondary">${texts.personalize || 'Personalizar'}</button>
+                            <button id="cck-reject-btn" class="cck-btn cck-btn-primary">${texts.rejectAll || 'Rechazar todas'}</button>
+                            <button id="cck-accept-btn" class="cck-btn cck-btn-primary">${texts.acceptAll || 'Aceptar todas'}</button>
+                        </div>
+                    </section>
+                    <section class="cck-tab-panel" data-tab-panel="details" role="tabpanel" aria-hidden="true">
+                        <p class="cck-tab-description">${texts.detailsDescription || ''}</p>
+                        <div class="cck-options">
+                            <div class="cck-option"><label><strong>Necesario</strong> (Siempre activo)</label><label class="cck-switch"><input type="checkbox" data-consent="necessary" checked disabled><span class="cck-slider"></span></label></div>
+                            <div class="cck-option"><label>${texts.preferences || 'Preferencias'}</label><label class="cck-switch"><input type="checkbox" data-consent="preferences"><span class="cck-slider"></span></label></div>
+                            <div class="cck-option"><label>${texts.analytics || 'Análisis'}</label><label class="cck-switch"><input type="checkbox" data-consent="analytics"><span class="cck-slider"></span></label></div>
+                            <div class="cck-option"><label>${texts.marketing || 'Marketing'}</label><label class="cck-switch"><input type="checkbox" data-consent="marketing"><span class="cck-slider"></span></label></div>
+                        </div>
+                        <div class="cck-actions"><button id="cck-save-btn" class="cck-btn cck-btn-primary">${texts.savePreferences || 'Guardar preferencias'}</button></div>
+                    </section>
+                    <section class="cck-tab-panel" data-tab-panel="about" role="tabpanel" aria-hidden="true">
+                        <p class="cck-tab-description">${texts.aboutDescription || ''}</p>
+                    </section>
                 </div>
             </div>
         `;
@@ -111,19 +121,29 @@ document.addEventListener('DOMContentLoaded', () => {
     const addEventListeners = () => {
         document.getElementById('cck-accept-btn')?.addEventListener('click', () => saveConsent('accept_all', { necessary: true, preferences: true, analytics: true, marketing: true }));
         document.getElementById('cck-reject-btn')?.addEventListener('click', () => saveConsent('reject_all', { necessary: true, preferences: false, analytics: false, marketing: false }));
-        
-        const settingsView = document.querySelector('.cck-settings');
-        const mainView = document.querySelector('.cck-main');
 
-        document.getElementById('cck-personalize-btn')?.addEventListener('click', () => {
-            if (mainView) mainView.style.display = 'none';
-            if (settingsView) settingsView.style.display = 'block';
+        const tabButtons = document.querySelectorAll('.cck-tab-btn');
+        const tabPanels = document.querySelectorAll('.cck-tab-panel');
+
+        const setActiveTab = (targetTab) => {
+            tabButtons.forEach(button => {
+                const isActive = button.dataset.tab === targetTab;
+                button.classList.toggle('cck-active', isActive);
+                button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+            });
+
+            tabPanels.forEach(panel => {
+                const isActive = panel.dataset.tabPanel === targetTab;
+                panel.classList.toggle('cck-active', isActive);
+                panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+            });
+        };
+
+        tabButtons.forEach(button => {
+            button.addEventListener('click', () => setActiveTab(button.dataset.tab));
         });
 
-        document.getElementById('cck-close-btn')?.addEventListener('click', () => {
-            if (settingsView) settingsView.style.display = 'none';
-            if (mainView) mainView.style.display = 'block';
-        });
+        document.getElementById('cck-personalize-btn')?.addEventListener('click', () => setActiveTab('details'));
 
         document.querySelectorAll('.cck-switch input').forEach(input => {
             input.addEventListener('change', (e) => {

--- a/public/class-cck-public.php
+++ b/public/class-cck-public.php
@@ -15,19 +15,26 @@ class CCK_Public {
         $title = $options['title'] ?? __('Política de Cookies', 'cookie-consent-king');
         $message = $options['message'] ?? __('Utilizamos cookies esenciales para el funcionamiento del sitio y cookies de análisis para mejorar tu experiencia. Puedes aceptar todas, rechazarlas o personalizar tus preferencias. Lee nuestra {privacy_policy_link}.', 'cookie-consent-king');
         $privacy_url = $options['privacy_policy_url'] ?? '';
+        $details_description = $options['details_description'] ?? __('Elige qué categorías de cookies quieres activar. Puedes modificar tu elección en cualquier momento.', 'cookie-consent-king');
+        $rgpd_text = $options['rgpd_text'] ?? __('Cumplimos con el RGPD. Consulta nuestra {privacy_policy_link} para obtener más información sobre cómo utilizamos las cookies.', 'cookie-consent-king');
 
         if (function_exists('pll__')) {
             $title = pll__($title);
             $message = pll__($message);
+            $details_description = pll__($details_description);
+            $rgpd_text = pll__($rgpd_text);
         }
         if (function_exists('do_action')) {
             $title = apply_filters('wpml_translate_string', $title, 'Banner Title', ['domain' => 'Cookie Consent King']);
             $message = apply_filters('wpml_translate_string', $message, 'Banner Message', ['domain' => 'Cookie Consent King']);
+            $details_description = apply_filters('wpml_translate_string', $details_description, 'Banner Details Description', ['domain' => 'Cookie Consent King']);
+            $rgpd_text = apply_filters('wpml_translate_string', $rgpd_text, 'Banner RGPD Text', ['domain' => 'Cookie Consent King']);
         }
-        
+
         $privacy_link_text = __('política de privacidad', 'cookie-consent-king');
         $privacy_link = !empty($privacy_url) ? "<a href='" . esc_url($privacy_url) . "' target='_blank' rel='noopener noreferrer'>$privacy_link_text</a>" : '';
         $message_processed = str_replace('{privacy_policy_link}', $privacy_link, $message);
+        $rgpd_text_processed = str_replace('{privacy_policy_link}', $privacy_link, $rgpd_text);
 
         $texts = [
             'title' => $title,
@@ -39,6 +46,11 @@ class CCK_Public {
             'preferences' => __('Preferencias', 'cookie-consent-king'),
             'analytics' => __('Análisis', 'cookie-consent-king'),
             'marketing' => __('Marketing', 'cookie-consent-king'),
+            'consentTab' => __('Consentimiento', 'cookie-consent-king'),
+            'detailsTab' => __('Detalles', 'cookie-consent-king'),
+            'aboutTab' => __('Acerca de las cookies', 'cookie-consent-king'),
+            'detailsDescription' => $details_description,
+            'aboutDescription' => $rgpd_text_processed,
         ];
 
         wp_localize_script('cck-banner', 'cckData', [


### PR DESCRIPTION
## Summary
- restructure the banner markup to use tabbed navigation separating consent actions, category details, and RGPD information
- update banner styles to support the new tab buttons and descriptive content areas
- expose additional localized texts through `cckData` for tab labels and RGPD copy

## Testing
- php -l public/class-cck-public.php

------
https://chatgpt.com/codex/tasks/task_e_68cdc37cd570833085c89ebe10ec4d7f