### PR TITLE
Add consent-aware blocking for third-party scripts

### DIFF
--- a/public/cck-banner.js
+++ b/public/cck-banner.js
@@ -4,24 +4,33 @@ document.addEventListener('DOMContentLoaded', () => {
         console.warn('Cookie Consent King: Data object not found.');
         return;
     }
-    
+
     const texts = data.texts || {};
     const bannerContainer = document.getElementById('cck-banner-container');
     const reopenContainer = document.getElementById('cck-reopen-trigger-container');
     if (!bannerContainer || !reopenContainer) return;
 
-    let consentState = {
+    const executedCallbackTokens = new Set();
+    let consentState = Object.assign({
         necessary: true,
         preferences: false,
         analytics: false,
         marketing: false,
-    };
+    }, data.consentState || {});
 
     const getCookie = (name) => {
         const value = `; ${document.cookie}`;
         const parts = value.split(`; ${name}=`);
         if (parts.length === 2) return parts.pop().split(';').shift();
         return null;
+    };
+
+    const parseJSON = (value, fallback = null) => {
+        try {
+            return JSON.parse(value);
+        } catch (e) {
+            return fallback;
+        }
     };
 
     const setCookie = (name, value, days) => {
@@ -32,6 +41,114 @@ document.addEventListener('DOMContentLoaded', () => {
             expires = "; expires=" + date.toUTCString();
         }
         document.cookie = name + "=" + (value || "") + expires + "; path=/; SameSite=Lax";
+    };
+
+    const resolveFunction = (path) => {
+        if (!path || typeof path !== 'string') return null;
+        return path.split('.').reduce((context, segment) => {
+            if (!context || typeof context !== 'object') {
+                return null;
+            }
+            return context[segment];
+        }, window);
+    };
+
+    const isCategoryAllowed = (category, state) => {
+        if (!category || category === 'necessary') return true;
+        return !!(state && state[category]);
+    };
+
+    const runConsentCallback = (callbackName, meta, state) => {
+        if (!callbackName) return;
+
+        const token = [callbackName, meta?.handle || '', meta?.category || ''].join('|');
+        if (executedCallbackTokens.has(token)) {
+            return;
+        }
+
+        const callback = resolveFunction(callbackName);
+        if (typeof callback === 'function') {
+            try {
+                callback(meta || {}, state || {});
+            } catch (error) {
+                console.error(`Cookie Consent King: error executing callback "${callbackName}"`, error);
+            }
+        } else {
+            console.warn(`Cookie Consent King: callback "${callbackName}" not found in window scope.`);
+        }
+
+        executedCallbackTokens.add(token);
+    };
+
+    const restoreScriptNode = (blockedNode, state) => {
+        if (!blockedNode || blockedNode.dataset.cckRestored === '1') return;
+        const category = blockedNode.dataset.cckConsent;
+        if (!isCategoryAllowed(category, state)) {
+            return;
+        }
+
+        const parent = blockedNode.parentNode;
+        if (!parent) return;
+
+        const replacement = document.createElement('script');
+        const originalAttrs = blockedNode.dataset.cckOrigAttrs ? parseJSON(blockedNode.dataset.cckOrigAttrs, {}) : {};
+        const originalType = blockedNode.dataset.cckOrigType || originalAttrs?.type || '';
+
+        if (blockedNode.dataset.cckSrc) {
+            replacement.src = blockedNode.dataset.cckSrc;
+        } else {
+            replacement.textContent = blockedNode.textContent;
+        }
+
+        if (originalType) {
+            replacement.type = originalType;
+        } else {
+            replacement.removeAttribute('type');
+        }
+
+        Object.entries(originalAttrs || {}).forEach(([name, value]) => {
+            if (['src', 'type'].includes(name)) {
+                return;
+            }
+            if (value === '') {
+                replacement.setAttribute(name, '');
+            } else {
+                replacement.setAttribute(name, value);
+            }
+        });
+
+        blockedNode.dataset.cckRestored = '1';
+        parent.replaceChild(replacement, blockedNode);
+
+        const callbackName = blockedNode.dataset.cckCallback;
+        runConsentCallback(callbackName, {
+            handle: blockedNode.dataset.cckHandle,
+            category,
+            type: blockedNode.dataset.cckSrc ? 'external' : 'inline',
+        }, state);
+    };
+
+    const restoreBlockedScripts = (state) => {
+        const blockedNodes = document.querySelectorAll('script[data-cck-blocked="1"]');
+        blockedNodes.forEach(node => restoreScriptNode(node, state));
+
+        const stored = (window.cckData && Array.isArray(window.cckData.blockedScripts)) ? window.cckData.blockedScripts : [];
+        stored.forEach(item => {
+            if (!item || !isCategoryAllowed(item.category, state)) {
+                return;
+            }
+            runConsentCallback(item.callback, item, state);
+        });
+
+        document.dispatchEvent(new CustomEvent('cck:consent-applied', { detail: { consent: state } }));
+    };
+
+    const syncTogglesWithState = () => {
+        document.querySelectorAll('.cck-switch input').forEach(input => {
+            const key = input.dataset.consent;
+            if (!key || key === 'necessary') return;
+            input.checked = !!consentState[key];
+        });
     };
 
     const buildBanner = () => {
@@ -61,8 +178,9 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>
         `;
         addEventListeners();
+        syncTogglesWithState();
     };
-    
+
     const buildReopenTrigger = () => {
         if (!data.reopen_icon_url) return;
         reopenContainer.innerHTML = `
@@ -76,25 +194,30 @@ document.addEventListener('DOMContentLoaded', () => {
                 buildBanner();
             }
             setTimeout(showBanner, 50);
+            syncTogglesWithState();
         });
         setTimeout(() => trigger?.classList.add('cck-visible'), 100);
     };
 
     const saveConsent = (action, details) => {
-        setCookie('cck_consent', JSON.stringify(details), 365);
+        const nextState = Object.assign({}, { necessary: true }, consentState, details || {});
+        consentState = nextState;
+        setCookie('cck_consent', JSON.stringify(nextState), 365);
         hideBanner();
         if (!document.getElementById('cck-reopen-trigger')) {
             buildReopenTrigger();
         }
 
+        restoreBlockedScripts(consentState);
+
         const formData = new URLSearchParams();
         formData.append('action', 'cck_log_consent');
         formData.append('nonce', data.nonce);
         formData.append('consent_action', action);
-        formData.append('consent_details', JSON.stringify(details));
-        fetch(data.ajax_url, { 
-            method: 'POST', 
-            body: formData 
+        formData.append('consent_details', JSON.stringify(nextState));
+        fetch(data.ajax_url, {
+            method: 'POST',
+            body: formData
         }).catch(error => console.error('Error logging consent:', error));
     };
 
@@ -111,7 +234,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const addEventListeners = () => {
         document.getElementById('cck-accept-btn')?.addEventListener('click', () => saveConsent('accept_all', { necessary: true, preferences: true, analytics: true, marketing: true }));
         document.getElementById('cck-reject-btn')?.addEventListener('click', () => saveConsent('reject_all', { necessary: true, preferences: false, analytics: false, marketing: false }));
-        
+
         const settingsView = document.querySelector('.cck-settings');
         const mainView = document.querySelector('.cck-main');
 
@@ -127,7 +250,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         document.querySelectorAll('.cck-switch input').forEach(input => {
             input.addEventListener('change', (e) => {
-                if(e.target.dataset.consent !== 'necessary') {
+                if (e.target.dataset.consent !== 'necessary') {
                     consentState[e.target.dataset.consent] = e.target.checked;
                 }
             });
@@ -137,10 +260,19 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const existingCookie = getCookie('cck_consent');
+    if (existingCookie) {
+        const parsed = parseJSON(existingCookie);
+        if (parsed) {
+            consentState = Object.assign({}, consentState, parsed);
+        }
+    }
+
     if (!existingCookie) {
         buildBanner();
         setTimeout(showBanner, 100);
     } else {
         buildReopenTrigger();
     }
+
+    restoreBlockedScripts(consentState);
 });

--- a/public/class-cck-public.php
+++ b/public/class-cck-public.php
@@ -1,9 +1,121 @@
 <?php
 class CCK_Public {
 
+    /**
+     * Instance reference used to expose the registration helpers before the
+     * object is constructed by WordPress.
+     *
+     * @var self|null
+     */
+    protected static $instance = null;
+
+    /**
+     * Cache of registered script handles and their metadata.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    protected $script_registry = [];
+
+    /**
+     * Blocked scripts collected during the request lifecycle.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    protected $blocked_scripts = [];
+
+    /**
+     * Memoized consent state decoded from the consent cookie.
+     *
+     * @var array<string, bool>
+     */
+    protected $consent_cache = [];
+
+    /**
+     * Flag to avoid starting multiple output buffers.
+     *
+     * @var bool
+     */
+    protected $buffer_active = false;
+
     public function __construct() {
+        self::$instance = $this;
+
         add_action('wp_enqueue_scripts', [$this, 'enqueue_public_assets']);
         add_action('wp_footer', [$this, 'render_banner_html'], 999);
+
+        if (!is_admin()) {
+            add_filter('script_loader_tag', [$this, 'filter_script_loader_tag'], 10, 3);
+            add_action('template_redirect', [$this, 'start_output_buffer'], 0);
+            add_action('shutdown', [$this, 'end_output_buffer'], 0);
+            add_action('wp_footer', [$this, 'print_blocked_scripts_store'], 5);
+        }
+    }
+
+    /**
+     * Registers a third-party script handle that must wait for consent before
+     * being executed.
+     *
+     * This method can be used directly or through the static proxy
+     * {@see CCK_Public::register_script_category()} to ensure compatibility with
+     * page builders (Elementor, Divi, etc.) that register their scripts outside
+     * the standard WordPress enqueue flow.
+     *
+     * Inline scripts rendered directly by builders can alternatively declare the
+     * category using the `data-cck-consent` attribute, which is handled by the
+     * output buffer started by this class.
+     *
+     * @param string $handle   Script handle passed to wp_enqueue_script().
+     * @param string $category Consent category (e.g. analytics, marketing).
+     * @param array  $args     Optional metadata. Supported keys:
+     *                         - callback: JavaScript function name executed when
+     *                                     consent for the category is granted.
+     *                         - description: Developer note stored with the
+     *                                         blocked script information.
+     */
+    public function register_third_party_script($handle, $category, array $args = []) {
+        if (empty($handle) || empty($category)) {
+            return;
+        }
+
+        $defaults = [
+            'category' => $category,
+            'callback' => $args['callback'] ?? '',
+            'description' => $args['description'] ?? '',
+        ];
+
+        $this->script_registry[$handle] = $defaults;
+    }
+
+    /**
+     * Static proxy that allows other plugins to register scripts even before the
+     * public instance is fully initialised by WordPress.
+     *
+     * Example usage for Elementor widgets:
+     *
+     * ```php
+     * add_action( 'elementor/frontend/before_enqueue_scripts', function() {
+     *     \CCK_Public::register_script_category( 'google-maps', 'preferences', [
+     *         'callback' => 'initGoogleMapsWidget',
+     *     ] );
+     * } );
+     * ```
+     *
+     * @param string $handle   Script handle passed to wp_enqueue_script().
+     * @param string $category Consent category slug.
+     * @param array  $args     Optional metadata forwarded to
+     *                         register_third_party_script().
+     */
+    public static function register_script_category($handle, $category, array $args = []) {
+        if (self::$instance instanceof self) {
+            self::$instance->register_third_party_script($handle, $category, $args);
+            return;
+        }
+
+        add_action('plugins_loaded', function () use ($handle, $category, $args) {
+            if (self::$instance instanceof self) {
+                self::$instance->register_third_party_script($handle, $category, $args);
+            }
+        });
     }
 
     public function enqueue_public_assets() {
@@ -46,6 +158,8 @@ class CCK_Public {
             'nonce' => wp_create_nonce('cck_log_consent_nonce'),
             'icon_url' => esc_url($options['icon_url'] ?? ''),
             'reopen_icon_url' => esc_url($options['reopen_icon_url'] ?? ''),
+            'consentState' => $this->get_user_consent_state(),
+            'blockedScripts' => [],
             'texts'    => $texts,
         ]);
         
@@ -61,5 +175,279 @@ class CCK_Public {
     public function render_banner_html() {
         echo '<div id="cck-banner-container"></div>';
         echo '<div id="cck-reopen-trigger-container"></div>';
+    }
+
+    /**
+     * Filters enqueued script tags to prevent execution until consent is granted.
+     *
+     * @param string $tag    The full script tag generated by WordPress.
+     * @param string $handle The registered script handle.
+     * @param string $src    Script source URL.
+     *
+     * @return string
+     */
+    public function filter_script_loader_tag($tag, $handle, $src) {
+        $registration = $this->script_registry[$handle] ?? [];
+        $category = $registration['category'] ?? apply_filters('cck_script_category', '', $handle, $src, $tag);
+
+        if (empty($category) || $this->user_has_consent($category)) {
+            return $tag;
+        }
+
+        $context = array_merge($registration, [
+            'handle' => $handle,
+            'src' => $src,
+        ]);
+
+        $blocked_tag = $this->block_script_tag($tag, $category, $context);
+        $this->remember_blocked_script($category, $context);
+
+        return $blocked_tag;
+    }
+
+    /**
+     * Starts an output buffer to catch inline scripts emitted directly by page builders.
+     */
+    public function start_output_buffer() {
+        if ($this->buffer_active || wp_doing_ajax() || wp_doing_cron()) {
+            return;
+        }
+
+        $this->buffer_active = ob_start([$this, 'process_buffer_output']);
+    }
+
+    /**
+     * Flushes the output buffer created for inline scripts.
+     */
+    public function end_output_buffer() {
+        if ($this->buffer_active) {
+            ob_end_flush();
+            $this->buffer_active = false;
+        }
+    }
+
+    /**
+     * Processes buffered HTML and marks inline scripts requiring consent.
+     *
+     * Page builders that output raw HTML (Elementor, Divi, Gutenberg blocks,
+     * etc.) can opt into the consent workflow by adding the
+     * `data-cck-consent="{category}"` attribute to their script tags. The
+     * buffer converts those tags into placeholders until the visitor grants the
+     * required consent.
+     *
+     * @param string $html Buffered HTML output.
+     *
+     * @return string
+     */
+    public function process_buffer_output($html) {
+        if (false === stripos($html, '<script')) {
+            return $html;
+        }
+
+        return preg_replace_callback('/<script\b([^>]*)>(.*?)<\/script>/is', function ($matches) {
+            $attribute_string = $matches[1];
+            $content = $matches[2];
+
+            $attributes = $this->parse_attributes_from_string($attribute_string);
+
+            if (empty($attributes['data-cck-consent']) || !empty($attributes['data-cck-blocked'])) {
+                return $matches[0];
+            }
+
+            $category = $attributes['data-cck-consent'];
+
+            if ($this->user_has_consent($category)) {
+                return $matches[0];
+            }
+
+            $context = [
+                'handle' => $attributes['id'] ?? null,
+                'callback' => $attributes['data-cck-callback'] ?? '',
+                'type' => 'inline',
+            ];
+
+            $script_tag = '<script' . $attribute_string . '>' . $content . '</script>';
+            $blocked_tag = $this->block_script_tag($script_tag, $category, $context);
+
+            $this->remember_blocked_script($category, $context);
+
+            return $blocked_tag;
+        }, $html);
+    }
+
+    /**
+     * Prints the blocked script registry so JavaScript can attempt re-execution
+     * once consent is granted.
+     */
+    public function print_blocked_scripts_store() {
+        $blocked = wp_json_encode(array_values($this->blocked_scripts));
+
+        printf(
+            '<script id="cck-blocked-scripts-store">window.cckData = window.cckData || {}; window.cckData.blockedScripts = %s;</script>',
+            $blocked ? $blocked : '[]'
+        );
+    }
+
+    /**
+     * Converts a script tag into a consent-aware placeholder.
+     *
+     * @param string $tag      Original script tag.
+     * @param string $category Consent category slug.
+     * @param array  $context  Additional metadata such as handle or callback.
+     *
+     * @return string
+     */
+    protected function block_script_tag($tag, $category, array $context = []) {
+        if (!preg_match('/<script\b([^>]*)>(.*?)<\/script>/is', $tag, $matches)) {
+            return $tag;
+        }
+
+        $attribute_string = $matches[1];
+        $content = $matches[2];
+
+        $attributes = $this->parse_attributes_from_string($attribute_string);
+        $original_attributes = $attributes;
+
+        if (isset($attributes['src']) && !empty($attributes['src'])) {
+            $attributes['data-cck-src'] = $attributes['src'];
+            unset($attributes['src']);
+        }
+
+        if (isset($attributes['type'])) {
+            $context['original_type'] = $attributes['type'];
+        }
+
+        $attributes['type'] = 'text/plain';
+        $attributes['data-cck-blocked'] = '1';
+        $attributes['data-cck-consent'] = $category;
+
+        if (!empty($context['handle'])) {
+            $attributes['data-cck-handle'] = $context['handle'];
+        }
+
+        if (!empty($context['callback'])) {
+            $attributes['data-cck-callback'] = $context['callback'];
+        }
+
+        if (!empty($context['original_type'])) {
+            $attributes['data-cck-orig-type'] = $context['original_type'];
+        }
+
+        if (!empty($original_attributes)) {
+            $attributes['data-cck-orig-attrs'] = wp_json_encode($original_attributes);
+        }
+
+        $attribute_html = $this->render_attributes($attributes);
+
+        return '<script' . $attribute_html . '>' . $content . '</script>';
+    }
+
+    /**
+     * Stores blocked script metadata for later restoration.
+     *
+     * @param string $category Consent category slug.
+     * @param array  $context  Additional metadata captured while blocking.
+     */
+    protected function remember_blocked_script($category, array $context = []) {
+        $this->blocked_scripts[] = [
+            'category' => $category,
+            'handle' => $context['handle'] ?? '',
+            'callback' => $context['callback'] ?? '',
+            'description' => $context['description'] ?? '',
+            'type' => empty($context['src']) ? 'inline' : 'external',
+        ];
+    }
+
+    /**
+     * Parses an HTML attribute string into an associative array.
+     *
+     * @param string $attribute_string Raw attribute string.
+     *
+     * @return array<string, string>
+     */
+    protected function parse_attributes_from_string($attribute_string) {
+        $parsed = [];
+        $hair = wp_kses_hair($attribute_string, wp_allowed_protocols());
+
+        foreach ($hair as $info) {
+            $parsed[$info['name']] = $info['value'];
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * Renders an associative array of attributes into HTML.
+     *
+     * @param array<string, string> $attributes Attribute map.
+     *
+     * @return string
+     */
+    protected function render_attributes(array $attributes) {
+        $html = '';
+
+        foreach ($attributes as $name => $value) {
+            if ('' === $value) {
+                $html .= ' ' . esc_attr($name);
+                continue;
+            }
+
+            $html .= sprintf(' %s="%s"', esc_attr($name), esc_attr($value));
+        }
+
+        return $html;
+    }
+
+    /**
+     * Returns the decoded consent state from the cookie.
+     *
+     * @return array<string, bool>
+     */
+    protected function get_user_consent_state() {
+        if (!empty($this->consent_cache)) {
+            return $this->consent_cache;
+        }
+
+        $defaults = [
+            'necessary' => true,
+            'preferences' => false,
+            'analytics' => false,
+            'marketing' => false,
+        ];
+
+        $cookie = $_COOKIE['cck_consent'] ?? '';
+
+        if (empty($cookie)) {
+            $this->consent_cache = $defaults;
+            return $this->consent_cache;
+        }
+
+        $decoded = json_decode(stripslashes($cookie), true);
+
+        if (!is_array($decoded)) {
+            $this->consent_cache = $defaults;
+            return $this->consent_cache;
+        }
+
+        $this->consent_cache = array_merge($defaults, array_map('boolval', $decoded));
+
+        return $this->consent_cache;
+    }
+
+    /**
+     * Checks whether consent for a category has already been granted.
+     *
+     * @param string $category Consent category slug.
+     *
+     * @return bool
+     */
+    protected function user_has_consent($category) {
+        if ('necessary' === $category) {
+            return true;
+        }
+
+        $state = $this->get_user_consent_state();
+
+        return !empty($state[$category]);
     }
 }


### PR DESCRIPTION
## Summary
- add registration helpers and consent-aware filtering for third-party scripts
- buffer and annotate inline scripts that declare consent categories
- extend the front-end banner logic to restore blocked assets once consent is granted and expose callbacks for builders

## Testing
- php -l public/class-cck-public.php
- node --check public/cck-banner.js

------
https://chatgpt.com/codex/tasks/task_e_68cdc38395d08330a32f4e8d2da2e5e7