### PR TITLE
Scan and display cookie categories

### DIFF
--- a/public/cck-banner.css
+++ b/public/cck-banner.css
@@ -16,6 +16,11 @@
 .cck-settings-header { display: flex; justify-content: space-between; align-items: center; }
 .cck-settings-title { font-size: 18px; font-weight: 600; }
 .cck-close-btn { background: none; border: none; font-size: 24px; cursor: pointer; padding: 0; color: #888; }
+.cck-settings-tabs { display: flex; gap: 10px; margin-top: 20px; }
+.cck-settings-tab { flex: 1; background: transparent; border: 1px solid #e0e0e0; border-radius: 8px; padding: 10px 12px; font-size: 14px; font-weight: 500; cursor: pointer; transition: background-color 0.2s, color 0.2s, border-color 0.2s; }
+.cck-settings-tab.cck-tab-active { background: var(--cck-primary-btn-bg); color: var(--cck-primary-btn-text); border-color: var(--cck-primary-btn-bg); }
+.cck-tab-content { display: none; margin-top: 20px; }
+.cck-tab-content.cck-tab-active { display: block; }
 .cck-options { margin-top: 20px; display: flex; flex-direction: column; gap: 15px; }
 .cck-option { display: flex; justify-content: space-between; align-items: center; padding: 12px; border: 1px solid #eee; border-radius: 8px; }
 .cck-option label { font-weight: 500; }
@@ -26,6 +31,11 @@
 input:checked + .cck-slider { background-color: var(--cck-primary-btn-bg); }
 input:disabled + .cck-slider { background-color: #e0e0e0; cursor: not-allowed; }
 input:checked + .cck-slider:before { transform: translateX(20px); }
+.cck-cookie-summary { font-size: 14px; margin-bottom: 12px; }
+.cck-cookie-details-list { display: flex; flex-direction: column; gap: 10px; }
+.cck-cookie-detail { display: flex; justify-content: space-between; align-items: center; padding: 10px 12px; border: 1px solid #eee; border-radius: 8px; font-size: 13px; }
+.cck-cookie-detail-count { font-weight: 600; }
+.cck-cookie-empty { font-size: 13px; color: #666; margin: 0 0 12px; display: none; }
 #cck-reopen-trigger { position: fixed; bottom: 15px; left: 15px; width: 48px; height: 48px; background-color: var(--cck-bg-color, #fff); border-radius: 50%; box-shadow: 0 4px 10px rgba(0,0,0,0.2); cursor: pointer; z-index: 9997; display: none; align-items: center; justify-content: center; transform: scale(0.5); opacity: 0; transition: transform 0.3s ease, opacity 0.3s ease; }
 #cck-reopen-trigger.cck-visible { display: flex; transform: scale(1); opacity: 1; }
 #cck-reopen-trigger img { width: 28px; height: 28px; }

--- a/public/cck-banner.js
+++ b/public/cck-banner.js
@@ -17,6 +17,183 @@ document.addEventListener('DOMContentLoaded', () => {
         marketing: false,
     };
 
+    const defaultCookieCategories = {
+        necessary: {
+            label: texts.necessary || 'Necesario',
+            patterns: ['cck_consent', 'wordpress_logged_in_*', 'wp-settings-*', 'wp-settings-time-*'],
+            showInDetails: true,
+            fallback: false,
+        },
+        preferences: {
+            label: texts.preferences || 'Preferencias',
+            patterns: [],
+            showInDetails: true,
+        },
+        analytics: {
+            label: texts.analytics || 'Análisis',
+            patterns: ['_ga', '_gid', '_gat', '_gcl_au', '__utma', '__utmb', '__utmc', '__utmt', '__utmz'],
+            showInDetails: true,
+        },
+        marketing: {
+            label: texts.marketing || 'Marketing',
+            patterns: ['_fbp', 'fr', 'IDE', 'test_cookie', 'YSC', 'VISITOR_INFO1_LIVE', 'CONSENT', 'PREF'],
+            showInDetails: true,
+        },
+        uncategorized: {
+            label: texts.uncategorized || 'Sin clasificar',
+            patterns: [],
+            showInDetails: true,
+            fallback: true,
+        }
+    };
+
+    const mergeCookieCategories = () => {
+        const categoriesFromData = data.cookieCategories || {};
+        const merged = {};
+        Object.entries(defaultCookieCategories).forEach(([key, value]) => {
+            merged[key] = {
+                ...value,
+                patterns: [...(value.patterns || [])]
+            };
+        });
+
+        Object.entries(categoriesFromData).forEach(([key, value]) => {
+            const base = merged[key] || {};
+            const normalizedValue = (value && typeof value === 'object') ? value : {};
+            const overridePatterns = Array.isArray(normalizedValue.patterns) ? normalizedValue.patterns : null;
+            merged[key] = {
+                ...base,
+                ...normalizedValue,
+                patterns: overridePatterns ? [...overridePatterns] : [...(base.patterns || [])]
+            };
+        });
+
+        if (!Object.values(merged).some(category => category.fallback)) {
+            merged.uncategorized = merged.uncategorized || {
+                label: texts.uncategorized || 'Sin clasificar',
+                patterns: [],
+                showInDetails: true,
+                fallback: true,
+            };
+            merged.uncategorized.fallback = true;
+        }
+
+        return merged;
+    };
+
+    const cookieCategories = mergeCookieCategories();
+
+    const buildEmptySummary = () => {
+        const counts = {};
+        const cookies = {};
+        Object.keys(cookieCategories).forEach((category) => {
+            counts[category] = 0;
+            cookies[category] = [];
+        });
+        return { counts, cookies, total: 0 };
+    };
+
+    let cookieSummary = buildEmptySummary();
+
+    const wildcardToRegExp = (pattern) => {
+        const escaped = pattern.replace(/[.*+?^${}()|[\]\]/g, '\$&').replace(/\\\*/g, '.*');
+        return new RegExp(`^${escaped}$`, 'i');
+    };
+
+    const patternMatches = (pattern, cookieName) => {
+        if (!pattern) return false;
+        if (pattern instanceof RegExp) {
+            return pattern.test(cookieName);
+        }
+        if (typeof pattern === 'string') {
+            if (pattern.includes('*')) {
+                return wildcardToRegExp(pattern).test(cookieName);
+            }
+            return pattern.toLowerCase() === cookieName.toLowerCase();
+        }
+        return false;
+    };
+
+    const getFallbackCategoryKey = () => {
+        const fallbackEntry = Object.entries(cookieCategories).find(([, config]) => config.fallback);
+        return fallbackEntry ? fallbackEntry[0] : Object.keys(cookieCategories)[0];
+    };
+
+    const categorizeCookie = (cookieName) => {
+        const normalizedName = cookieName.trim();
+        for (const [categoryKey, config] of Object.entries(cookieCategories)) {
+            if (config?.patterns?.some(pattern => patternMatches(pattern, normalizedName))) {
+                return categoryKey;
+            }
+        }
+        return getFallbackCategoryKey();
+    };
+
+    const renderCookieSummary = () => {
+        const totalElement = document.getElementById('cck-cookie-total');
+        const listElement = document.getElementById('cck-cookie-details-list');
+        const emptyElement = document.getElementById('cck-cookie-empty');
+        if (!totalElement || !listElement) return;
+
+        totalElement.textContent = cookieSummary.total.toString();
+        listElement.innerHTML = '';
+
+        let hasVisibleCategory = false;
+
+        Object.entries(cookieCategories).forEach(([categoryKey, config]) => {
+            if (config.showInDetails === false) return;
+            hasVisibleCategory = true;
+            const count = cookieSummary.counts[categoryKey] || 0;
+            const label = config.label || categoryKey;
+            const row = document.createElement('div');
+            row.className = 'cck-cookie-detail';
+            const labelElement = document.createElement('span');
+            labelElement.className = 'cck-cookie-detail-label';
+            labelElement.textContent = label;
+            const countElement = document.createElement('span');
+            countElement.className = 'cck-cookie-detail-count';
+            countElement.textContent = count.toString();
+            row.append(labelElement, countElement);
+            listElement.appendChild(row);
+        });
+
+        if (emptyElement) {
+            if (!cookieSummary.total && hasVisibleCategory) {
+                emptyElement.style.display = 'block';
+            } else {
+                emptyElement.style.display = 'none';
+            }
+        }
+    };
+
+    const scanCookies = () => {
+        const summary = buildEmptySummary();
+        const rawCookies = document.cookie ? document.cookie.split(';') : [];
+
+        rawCookies.forEach((rawCookie) => {
+            const trimmed = rawCookie.trim();
+            if (!trimmed) return;
+            const separatorIndex = trimmed.indexOf('=');
+            const rawName = separatorIndex >= 0 ? trimmed.slice(0, separatorIndex) : trimmed;
+            let cookieName = rawName.trim();
+            try {
+                cookieName = decodeURIComponent(cookieName);
+            } catch (error) {
+                cookieName = rawName.trim();
+            }
+            if (!cookieName) return;
+            const category = categorizeCookie(cookieName);
+            summary.counts[category] = (summary.counts[category] || 0) + 1;
+            summary.cookies[category] = summary.cookies[category] || [];
+            summary.cookies[category].push(cookieName);
+            summary.total += 1;
+        });
+
+        cookieSummary = summary;
+        renderCookieSummary();
+        return summary;
+    };
+
     const getCookie = (name) => {
         const value = `; ${document.cookie}`;
         const parts = value.split(`; ${name}=`);
@@ -50,17 +227,29 @@ document.addEventListener('DOMContentLoaded', () => {
                 </div>
                 <div class="cck-settings">
                     <div class="cck-settings-header"><h3 class="cck-settings-title">${texts.personalize || 'Personalizar'}</h3><button id="cck-close-btn" class="cck-close-btn">&times;</button></div>
-                    <div class="cck-options">
-                        <div class="cck-option"><label><strong>Necesario</strong> (Siempre activo)</label><label class="cck-switch"><input type="checkbox" data-consent="necessary" checked disabled><span class="cck-slider"></span></label></div>
-                        <div class="cck-option"><label>${texts.preferences || 'Preferencias'}</label><label class="cck-switch"><input type="checkbox" data-consent="preferences"><span class="cck-slider"></span></label></div>
-                        <div class="cck-option"><label>${texts.analytics || 'Análisis'}</label><label class="cck-switch"><input type="checkbox" data-consent="analytics"><span class="cck-slider"></span></label></div>
-                        <div class="cck-option"><label>${texts.marketing || 'Marketing'}</label><label class="cck-switch"><input type="checkbox" data-consent="marketing"><span class="cck-slider"></span></label></div>
+                    <div class="cck-settings-tabs">
+                        <button class="cck-settings-tab" data-tab="preferences" type="button">${texts.personalize || 'Personalizar'}</button>
+                        <button class="cck-settings-tab" data-tab="details" type="button">${texts.details || 'Detalles'}</button>
                     </div>
-                    <div class="cck-actions"><button id="cck-save-btn" class="cck-btn cck-btn-primary">${texts.savePreferences || 'Guardar preferencias'}</button></div>
+                    <div class="cck-tab-content" data-tab="preferences">
+                        <div class="cck-options">
+                            <div class="cck-option"><label><strong>${texts.necessary || 'Necesario'}</strong> (Siempre activo)</label><label class="cck-switch"><input type="checkbox" data-consent="necessary" checked disabled><span class="cck-slider"></span></label></div>
+                            <div class="cck-option"><label>${texts.preferences || 'Preferencias'}</label><label class="cck-switch"><input type="checkbox" data-consent="preferences" ${consentState.preferences ? 'checked' : ''}><span class="cck-slider"></span></label></div>
+                            <div class="cck-option"><label>${texts.analytics || 'Análisis'}</label><label class="cck-switch"><input type="checkbox" data-consent="analytics" ${consentState.analytics ? 'checked' : ''}><span class="cck-slider"></span></label></div>
+                            <div class="cck-option"><label>${texts.marketing || 'Marketing'}</label><label class="cck-switch"><input type="checkbox" data-consent="marketing" ${consentState.marketing ? 'checked' : ''}><span class="cck-slider"></span></label></div>
+                        </div>
+                        <div class="cck-actions"><button id="cck-save-btn" class="cck-btn cck-btn-primary">${texts.savePreferences || 'Guardar preferencias'}</button></div>
+                    </div>
+                    <div class="cck-tab-content" data-tab="details">
+                        <div class="cck-cookie-summary"><strong>${texts.totalCookies || 'Cookies detectadas'}:</strong> <span id="cck-cookie-total">0</span></div>
+                        <p id="cck-cookie-empty" class="cck-cookie-empty">${texts.noCookiesDetected || 'No se detectaron cookies en esta sesión.'}</p>
+                        <div id="cck-cookie-details-list" class="cck-cookie-details-list"></div>
+                    </div>
                 </div>
             </div>
         `;
         addEventListeners();
+        renderCookieSummary();
     };
     
     const buildReopenTrigger = () => {
@@ -80,8 +269,37 @@ document.addEventListener('DOMContentLoaded', () => {
         setTimeout(() => trigger?.classList.add('cck-visible'), 100);
     };
 
-    const saveConsent = (action, details) => {
-        setCookie('cck_consent', JSON.stringify(details), 365);
+    const saveConsent = (action, updatedState) => {
+        if (updatedState) {
+            consentState = { ...consentState, ...updatedState };
+        }
+
+        const summary = scanCookies();
+        const cookiesByCategory = Object.entries(summary.cookies).reduce((accumulator, [category, cookies]) => {
+            accumulator[category] = Array.isArray(cookies) ? [...cookies] : [];
+            return accumulator;
+        }, {});
+
+        const categoriesMetadata = Object.entries(cookieCategories).reduce((accumulator, [category, config]) => {
+            accumulator[category] = {
+                label: config.label,
+                showInDetails: config.showInDetails !== false,
+            };
+            return accumulator;
+        }, {});
+
+        const consentPayload = {
+            ...consentState,
+            detectedCookies: {
+                total: summary.total,
+                counts: { ...summary.counts },
+                cookiesByCategory,
+                categories: categoriesMetadata,
+            }
+        };
+
+        setCookie('cck_consent', JSON.stringify(consentPayload), 365);
+        scanCookies();
         hideBanner();
         if (!document.getElementById('cck-reopen-trigger')) {
             buildReopenTrigger();
@@ -91,10 +309,10 @@ document.addEventListener('DOMContentLoaded', () => {
         formData.append('action', 'cck_log_consent');
         formData.append('nonce', data.nonce);
         formData.append('consent_action', action);
-        formData.append('consent_details', JSON.stringify(details));
-        fetch(data.ajax_url, { 
-            method: 'POST', 
-            body: formData 
+        formData.append('consent_details', JSON.stringify(consentPayload));
+        fetch(data.ajax_url, {
+            method: 'POST',
+            body: formData
         }).catch(error => console.error('Error logging consent:', error));
     };
 
@@ -111,13 +329,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const addEventListeners = () => {
         document.getElementById('cck-accept-btn')?.addEventListener('click', () => saveConsent('accept_all', { necessary: true, preferences: true, analytics: true, marketing: true }));
         document.getElementById('cck-reject-btn')?.addEventListener('click', () => saveConsent('reject_all', { necessary: true, preferences: false, analytics: false, marketing: false }));
-        
+
         const settingsView = document.querySelector('.cck-settings');
         const mainView = document.querySelector('.cck-main');
 
         document.getElementById('cck-personalize-btn')?.addEventListener('click', () => {
             if (mainView) mainView.style.display = 'none';
             if (settingsView) settingsView.style.display = 'block';
+            renderCookieSummary();
         });
 
         document.getElementById('cck-close-btn')?.addEventListener('click', () => {
@@ -133,14 +352,50 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
 
-        document.getElementById('cck-save-btn')?.addEventListener('click', () => saveConsent('custom_selection', consentState));
+        const tabButtons = document.querySelectorAll('.cck-settings-tab');
+        const tabContents = document.querySelectorAll('.cck-tab-content');
+
+        const activateTab = (tabName) => {
+            tabButtons.forEach((button) => {
+                const isActive = button.dataset.tab === tabName;
+                button.classList.toggle('cck-tab-active', isActive);
+                button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+            });
+            tabContents.forEach((content) => {
+                const isActive = content.dataset.tab === tabName;
+                content.classList.toggle('cck-tab-active', isActive);
+            });
+            if (tabName === 'details') {
+                scanCookies();
+            }
+        };
+
+        tabButtons.forEach((button) => {
+            button.addEventListener('click', () => activateTab(button.dataset.tab));
+        });
+
+        activateTab('preferences');
+
+        document.getElementById('cck-save-btn')?.addEventListener('click', () => saveConsent('custom_selection'));
     };
+
+    scanCookies();
 
     const existingCookie = getCookie('cck_consent');
     if (!existingCookie) {
         buildBanner();
         setTimeout(showBanner, 100);
     } else {
+        try {
+            const parsedConsent = JSON.parse(existingCookie);
+            ['preferences', 'analytics', 'marketing'].forEach((key) => {
+                if (typeof parsedConsent[key] === 'boolean') {
+                    consentState[key] = parsedConsent[key];
+                }
+            });
+        } catch (error) {
+            console.warn('Cookie Consent King: Unable to parse stored consent.', error);
+        }
         buildReopenTrigger();
     }
 });

--- a/public/class-cck-public.php
+++ b/public/class-cck-public.php
@@ -36,9 +36,14 @@ class CCK_Public {
             'rejectAll' => __('Rechazar todas', 'cookie-consent-king'),
             'personalize' => __('Personalizar', 'cookie-consent-king'),
             'savePreferences' => __('Guardar preferencias', 'cookie-consent-king'),
+            'details' => __('Detalles', 'cookie-consent-king'),
             'preferences' => __('Preferencias', 'cookie-consent-king'),
             'analytics' => __('Análisis', 'cookie-consent-king'),
             'marketing' => __('Marketing', 'cookie-consent-king'),
+            'necessary' => __('Necesario', 'cookie-consent-king'),
+            'totalCookies' => __('Cookies detectadas', 'cookie-consent-king'),
+            'noCookiesDetected' => __('No se detectaron cookies en esta sesión.', 'cookie-consent-king'),
+            'uncategorized' => __('Sin clasificar', 'cookie-consent-king'),
         ];
 
         wp_localize_script('cck-banner', 'cckData', [


### PR DESCRIPTION
## Summary
- add client-side cookie scanner to classify known cookies into configurable categories and expose totals in the consent payload
- expand the banner UI with a details tab that surfaces per-category counts alongside localized labels
- style the new details tab and register additional localized strings for reuse on the front end

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cdc37ed2708330b73fafa2b6674fb9