### PR TITLE
Fix wildcard regex escaping

### DIFF
--- a/public/cck-banner.js
+++ b/public/cck-banner.js
@@ -122,7 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let cookieSummary = buildEmptySummary();
 
     const wildcardToRegExp = (pattern) => {
-        const escaped = pattern.replace(/[.*+?^${}()|[\]\]/g, '\$&').replace(/\\\*/g, '.*');
+        const escaped = pattern.replace(/[.*+?^${}()|[\[\]\\]/g, '\$&').replace(/\\\*/g, '.*');
         return new RegExp(`^${escaped}$`, 'i');
     };
 


### PR DESCRIPTION
## Summary
- escape `[` when converting wildcard patterns to regular expressions to avoid invalid character classes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdc962d5148330bb1ae3c6ef38513a