### PR TITLE
Remove stray equality markers from banner script

### DIFF
--- a/public/cck-banner.js
+++ b/public/cck-banner.js
@@ -351,7 +351,6 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!key || key === 'necessary') return;
             input.checked = !!consentState[key];
         });
-==
     };
 
     const buildBanner = () => {


### PR DESCRIPTION
## Summary
- remove an unintended `==` line left after the `syncTogglesWithState` function in the banner script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdce78bcb88330b1b34b182c8e826f