### PR TITLE
Fix undefined consent logging details argument

### DIFF
--- a/public/cck-banner.js
+++ b/public/cck-banner.js
@@ -462,7 +462,12 @@ document.addEventListener('DOMContentLoaded', () => {
         scanCookies();
 
         hideBanner();
-        log(`Guardando consentimiento con la acción: ${action}.`, details);
+
+        const logDetails = {
+            action,
+            consent: consentPayload,
+        };
+        log('Guardando consentimiento.', logDetails);
         if (!document.getElementById('cck-reopen-trigger')) {
             buildReopenTrigger();
         }


### PR DESCRIPTION
## Summary
- replace the undefined `details` argument when logging consent decisions
- log a structured object with the consent action and payload to avoid runtime errors when saving

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdce7e438c8330b1e94da35ac872f3