### PR TITLE
Add helper to delete consent cookie

### DIFF
--- a/public/cck-banner.js
+++ b/public/cck-banner.js
@@ -245,6 +245,10 @@ document.addEventListener('DOMContentLoaded', () => {
         document.cookie = name + "=" + (value || "") + expires + "; path=/; SameSite=Lax";
     };
 
+    const deleteCookie = (name) => {
+        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; SameSite=Lax`;
+    };
+
     const resolveFunction = (path) => {
         if (!path || typeof path !== 'string') return null;
         return path.split('.').reduce((context, segment) => {


### PR DESCRIPTION
## Summary
- add a deleteCookie helper next to setCookie so the consent cookie can be cleared safely
- reuse the helper from resetConsentForTesting to avoid runtime errors when testing

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdce7ef4148330b8409d6e96270b29