### PR TITLE
Fix wildcard escape handling

### DIFF
--- a/public/cck-banner.js
+++ b/public/cck-banner.js
@@ -122,7 +122,13 @@ document.addEventListener('DOMContentLoaded', () => {
     let cookieSummary = buildEmptySummary();
 
     const wildcardToRegExp = (pattern) => {
-        const escaped = pattern.replace(/[.*+?^${}()|[\[\]\\]/g, '\$&').replace(/\\\*/g, '.*');
+        if (typeof pattern !== 'string') {
+            return null;
+        }
+
+        const escaped = pattern
+            .replace(/[.*+?^${}()|[\]\]/g, '\$&')
+            .replace(/\\\*/g, '.*');
         return new RegExp(`^${escaped}$`, 'i');
     };
 
@@ -133,7 +139,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (typeof pattern === 'string') {
             if (pattern.includes('*')) {
-                return wildcardToRegExp(pattern).test(cookieName);
+                const wildcardRegex = wildcardToRegExp(pattern);
+                return wildcardRegex ? wildcardRegex.test(cookieName) : false;
             }
             return pattern.toLowerCase() === cookieName.toLowerCase();
         }


### PR DESCRIPTION
## Summary
- use the standard escape pattern inside `wildcardToRegExp` and keep the wildcard replacement safe
- short-circuit when a pattern is not a string and guard uses in `patternMatches`

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cdce779bf483308111c3203e3221f8