### PR TITLE
Fix bracket escaping in wildcard regex helper

### DIFF
--- a/public/cck-banner.js
+++ b/public/cck-banner.js
@@ -127,7 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         const escaped = pattern
-            .replace(/[.*+?^${}()|[\]\]/g, '\$&')
+            .replace(/[.*+?^${}()|\[\]\\]/g, '\$&')
             .replace(/\\\*/g, '.*');
         return new RegExp(`^${escaped}$`, 'i');
     };


### PR DESCRIPTION
## Summary
- ensure the regex-escaping helper handles literal [ characters correctly by updating the character class in `wildcardToRegExp`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdd182f3908330853cd60224626345