### PR TITLE
Fix escaping in wildcard regex

### DIFF
--- a/public/cck-banner.js
+++ b/public/cck-banner.js
@@ -127,7 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         const escaped = pattern
-            .replace(/[.*+?^${}()|[\]\]/g, '\$&')
+            .replace(/[.*+?^${}()|\[\]\\]/g, '\$&')
             .replace(/\\\*/g, '.*');
         return new RegExp(`^${escaped}$`, 'i');
     };


### PR DESCRIPTION
## Summary
- correct the escaping of square brackets in the wildcard-to-RegExp helper to avoid invalid patterns

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cdd2461f508330b5df67ed0ebb8de5