### PR TITLE
Add consent banner main panel markup and testing control

### DIFF
--- a/public/cck-banner.js
+++ b/public/cck-banner.js
@@ -369,6 +369,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const iconHtml = data.icon_url ? `<img src="${data.icon_url}" alt="Icon" class="cck-icon">` : '';
         log('Construyendo banner principal.');
 
+        const helpLinkHtml = testButtonHelpUrl
+            ? `<a href="${testButtonHelpUrl}" class="cck-test-link" target="_blank" rel="noopener noreferrer">${testButtonHelpLabel || testButtonHelpUrl}</a>`
+            : '';
+        const showTestControls = Boolean(testButtonLabel);
+
         bannerContainer.innerHTML = `
             <div id="cck-banner-backdrop"></div>
             <div id="cck-banner" class="cck-banner">
@@ -377,7 +382,25 @@ document.addEventListener('DOMContentLoaded', () => {
                     <button class="cck-tab-btn" data-tab="details" role="tab" aria-selected="false">${texts.detailsTab || 'Detalles'}</button>
                     <button class="cck-tab-btn" data-tab="about" role="tab" aria-selected="false">${texts.aboutTab || 'Acerca de las cookies'}</button>
                 </div>
-                <div class="cck-settings">
+                <div class="cck-main" data-tab-panel="consent">
+                    <div class="cck-tab-panels">
+                        <div class="cck-tab-panel cck-active" data-panel="consent">
+                            <div class="cck-header">
+                                ${iconHtml}
+                                <div>
+                                    <h2 class="cck-title">${texts.title || 'Política de Cookies'}</h2>
+                                    <p class="cck-message">${texts.message || ''}</p>
+                                </div>
+                            </div>
+                            <div class="cck-actions">
+                                <button id="cck-reject-btn" class="cck-btn cck-btn-secondary">${texts.rejectAll || 'Rechazar todas'}</button>
+                                <button id="cck-personalize-btn" class="cck-btn cck-btn-secondary">${texts.personalize || 'Personalizar'}</button>
+                                <button id="cck-accept-btn" class="cck-btn cck-btn-primary">${texts.acceptAll || 'Aceptar todas'}</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="cck-settings" data-tab-panel="settings" style="display: none;">
                     <div class="cck-settings-header"><h3 class="cck-settings-title">${texts.personalize || 'Personalizar'}</h3><button id="cck-close-btn" class="cck-close-btn">&times;</button></div>
                     <div class="cck-settings-tabs">
                         <button class="cck-settings-tab" data-tab="preferences" type="button">${texts.personalize || 'Personalizar'}</button>
@@ -399,6 +422,11 @@ document.addEventListener('DOMContentLoaded', () => {
                     </div>
 
                 </div>
+                ${showTestControls ? `
+                <div class="cck-test-controls">
+                    <button id="cck-test-btn" class="cck-btn cck-btn-tertiary" type="button">${testButtonLabel}</button>
+                    ${helpLinkHtml}
+                </div>` : ''}
             </div>
         `;
         addEventListeners();
@@ -532,6 +560,13 @@ document.addEventListener('DOMContentLoaded', () => {
         const tabButtons = document.querySelectorAll('.cck-settings-tab');
         const tabContents = document.querySelectorAll('.cck-tab-content');
 
+        if (settingsView) {
+            settingsView.style.display = 'none';
+        }
+        if (mainView) {
+            mainView.style.display = 'block';
+        }
+
         const activateTab = (tabName) => {
             tabButtons.forEach((button) => {
                 const isActive = button.dataset.tab === tabName;
@@ -561,6 +596,8 @@ document.addEventListener('DOMContentLoaded', () => {
             log('Vista principal restaurada sin cerrar el banner.');
 
         });
+
+        document.getElementById('cck-test-btn')?.addEventListener('click', resetConsentForTesting);
 
         document.querySelectorAll('.cck-switch input').forEach(input => {
             input.addEventListener('change', (e) => {

--- a/public/class-cck-public.php
+++ b/public/class-cck-public.php
@@ -178,6 +178,13 @@ class CCK_Public {
             'reopen_icon_url' => esc_url($options['reopen_icon_url'] ?? ''),
             'consentState' => $this->get_user_consent_state(),
             'blockedScripts' => [],
+            'forceShow' => !empty($force_show),
+            'debug' => !empty($debug_mode),
+            'testButton' => [
+                'text' => $test_button_text,
+                'helpUrl' => $test_button_url,
+                'helpLabel' => __('Ver guía de pruebas', 'cookie-consent-king'),
+            ],
 
             'texts'    => $texts,
         ]);


### PR DESCRIPTION
## Summary
- render the consent banner main panel with icon, text, action buttons, and optional test controls
- keep personalization settings hidden until requested and hook the reset control to the testing helper
- expose testing and debug configuration values to the localized banner script

## Testing
- php -l public/class-cck-public.php

------
https://chatgpt.com/codex/tasks/task_e_68d00c7c758c8330a58e875e7d5d4cbf