### PR TITLE
Fix wildcard regex escaping in banner script

### DIFF
--- a/public/cck-banner.js
+++ b/public/cck-banner.js
@@ -126,10 +126,18 @@ document.addEventListener('DOMContentLoaded', () => {
             return null;
         }
 
-        const escaped = pattern
-            .replace(/[.*+?^${}()|\[\]\\]/g, '\\$&')
-            .replace(/\\\*/g, '.*');
-        return new RegExp(`^${escaped}$`, 'i');
+        const escapeRegExp = (segment) => segment.replace(/[.*+?^${}()|[\\]\]/g, '\$&');
+        const normalizedPattern = pattern
+            .split('*')
+            .map(escapeRegExp)
+            .join('.*');
+
+        try {
+            return new RegExp(`^${normalizedPattern}$`, 'i');
+        } catch (error) {
+            log('Error creando RegExp para el patrón con comodines', pattern, error);
+            return null;
+        }
     };
 
     const patternMatches = (pattern, cookieName) => {


### PR DESCRIPTION
## Summary
- update `wildcardToRegExp` to escape literals safely before expanding wildcards
- add defensive error handling around the generated regular expression

## Testing
- node --check public/cck-banner.js
- node - <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68d00c78d77c8330a2801607c109ca1a