### PR TITLE
Align consent buttons and emit dataLayer events

### DIFF
--- a/public/cck-banner.css
+++ b/public/cck-banner.css
@@ -6,11 +6,15 @@
 .cck-title { font-size: 18px; font-weight: 600; margin: 0 0 8px; color: var(--cck-text-color); }
 .cck-message { font-size: 14px; line-height: 1.5; margin: 0; color: var(--cck-text-color); }
 .cck-message a { color: var(--cck-primary-btn-bg, #000); text-decoration: underline; }
-.cck-actions { display: flex; justify-content: flex-end; gap: 12px; margin-top: 24px; flex-wrap: wrap; }
+.cck-actions { display: flex; gap: 12px; margin-top: 24px; flex-wrap: wrap; }
+.cck-actions-main { justify-content: flex-start; }
+.cck-actions:not(.cck-actions-main) { justify-content: flex-end; }
 /* Estilo unificado para todos los botones */
 .cck-btn { padding: 10px 18px; border-radius: 8px; font-size: 14px; font-weight: 500; cursor: pointer; border: 1px solid transparent; transition: background-color 0.2s, color 0.2s, border-color 0.2s; background: var(--cck-primary-btn-bg); color: var(--cck-primary-btn-text); }
 /* Estilo específico para botones secundarios (como 'Volver') */
 .cck-btn.cck-btn-secondary { background: transparent; color: var(--cck-text-color); border-color: var(--cck-text-color); }
+.cck-link-btn { background: transparent; border: none; color: var(--cck-text-color); padding: 0; font-size: 14px; font-weight: 500; cursor: pointer; text-decoration: none; }
+.cck-link-btn:focus-visible, .cck-link-btn:hover { text-decoration: underline; }
 .cck-settings-title { font-size: 18px; font-weight: 600; margin-bottom: 16px; }
 .cck-options { display: flex; flex-direction: column; gap: 8px; }
 .cck-option { padding: 12px; border: 1px solid #eee; border-radius: 8px; }


### PR DESCRIPTION
## Summary
- reorder banner action buttons so Accept/Reject share the configured primary style and Personalize displays as text only
- adjust banner layout classes to left-align the primary actions while preserving settings view alignment
- push a dataLayer event on every consent save with action name and granted/denied categories

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3b42ddae883308cb296c3d6b06b51